### PR TITLE
Replace FT201XS with FT206S

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -305,8 +305,8 @@ ISR(PORTA_PORT_vect) {
     // and does not generate pin interrupts.
 
     if (PORTA.INTFLAGS & PIN7_bm) {
-        if (!(PORTA.IN & PIN7_bm)) {
-            // Falling edge: Enter sleep mode
+        if (PORTA.IN & PIN7_bm) {
+            // Rising edge: Enter sleep mode
 
             // Set PWM to 0%
             update_target_pwm(0);
@@ -320,7 +320,7 @@ ISR(PORTA_PORT_vect) {
             // Disable sleep after waking up
             sleep_disable();
         } else {
-            // Rising edge: Wake up and restore state
+            // Falling edge: Wake up and restore state
 
             // Restore PWM duty cycle
             update_target_pwm(pwm_target);

--- a/hardware/FTDI.kicad_sym
+++ b/hardware/FTDI.kicad_sym
@@ -1,0 +1,573 @@
+(kicad_symbol_lib
+	(version 20241209)
+	(generator "kicad_symbol_editor")
+	(generator_version "9.0")
+	(symbol "FT260S"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(property "Reference" "U"
+			(at 3.81 27.686 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "FT260S"
+			(at 4.064 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_SO:TSSOP-28_4.4x9.7mm_P0.65mm"
+			(at 0 -45.212 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://ftdichip.com/wp-content/uploads/2024/11/DS_FT260.pdf"
+			(at 0.508 -41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "HID-class USB to UART/I2C Bridge IC"
+			(at 0 -48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(symbol "FT260S_1_1"
+			(rectangle
+				(start -19.05 24.13)
+				(end 19.05 -24.13)
+				(stroke
+					(width 0)
+					(type solid)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin power_out line
+				(at -21.59 21.59 0)
+				(length 2.54)
+				(name "VCC3V3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "26"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -21.59 16.51 0)
+				(length 2.54)
+				(name "DEBUGGER"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -21.59 10.16 0)
+				(length 2.54)
+				(name "STEST_RSTN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -21.59 7.62 0)
+				(length 2.54)
+				(name "RESETN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -21.59 3.81 0)
+				(length 2.54)
+				(name "VBUS_DET"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -21.59 -3.81 0)
+				(length 2.54)
+				(name "DCNF0_I2C"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -21.59 -6.35 0)
+				(length 2.54)
+				(name "DCNF1_UART"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -21.59 -12.7 0)
+				(length 2.54)
+				(name "DM"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "24"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -21.59 -15.24 0)
+				(length 2.54)
+				(name "DP"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "25"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin input line
+				(at -21.59 -21.59 0)
+				(length 2.54)
+				(name "FSOURCE"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at -5.08 26.67 270)
+				(length 2.54)
+				(name "VCCIO"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "10"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at -5.08 -26.67 90)
+				(length 2.54)
+				(name "AGND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "28"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin power_in line
+				(at 0 26.67 270)
+				(length 2.54)
+				(name "VCCIN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "27"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -26.67 90)
+				(length 2.54)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "23"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 21.59 180)
+				(length 2.54)
+				(name "DIO5/SCL"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "16"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 19.05 180)
+				(length 2.54)
+				(name "DIO6/SDA"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "17"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 16.51 180)
+				(length 2.54)
+				(name "DIO8/INTRIN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "19"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 10.16 180)
+				(length 2.54)
+				(name "DIO3/RXD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "14"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 7.62 180)
+				(length 2.54)
+				(name "DIO4/TXD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "15"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 3.81 180)
+				(length 2.54)
+				(name "DIO1/RTSN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "12"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 1.27 180)
+				(length 2.54)
+				(name "DIO2/CTSN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "13"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -1.27 180)
+				(length 2.54)
+				(name "DIO9/DTRN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "20"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -3.81 180)
+				(length 2.54)
+				(name "DIO10/DCD"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "21"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -6.35 180)
+				(length 2.54)
+				(name "DIO11/RI"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "22"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -8.89 180)
+				(length 2.54)
+				(name "DIO13/GPIOH/DSRN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -12.7 180)
+				(length 2.54)
+				(name "DIO0/TX_ACT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "11"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -15.24 180)
+				(length 2.54)
+				(name "DIO12/BCD/RX_ACT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin bidirectional line
+				(at 21.59 -21.59 180)
+				(length 2.54)
+				(name "DIO7/#PWREN"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "18"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
+)

--- a/hardware/IntUsbPwmFanController.kicad_pro
+++ b/hardware/IntUsbPwmFanController.kicad_pro
@@ -246,7 +246,9 @@
   },
   "libraries": {
     "pinned_footprint_libs": [],
-    "pinned_symbol_libs": []
+    "pinned_symbol_libs": [
+      "FTDI"
+    ]
   },
   "meta": {
     "filename": "IntUsbPwmFanController.kicad_pro",

--- a/hardware/IntUsbPwmFanController.kicad_sch
+++ b/hardware/IntUsbPwmFanController.kicad_sch
@@ -1436,167 +1436,6 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "Device:C_Polarized"
-			(pin_numbers
-				(hide yes)
-			)
-			(pin_names
-				(offset 0.254)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "C"
-				(at 0.635 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Value" "C_Polarized"
-				(at 0.635 -2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Footprint" ""
-				(at 0.9652 -3.81 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Polarized capacitor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "cap capacitor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "CP_*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "C_Polarized_0_1"
-				(rectangle
-					(start -2.286 0.508)
-					(end 2.286 1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.778 2.286) (xy -0.762 2.286)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.27 2.794) (xy -1.27 1.778)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(rectangle
-					(start 2.286 -0.508)
-					(end -2.286 -1.016)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type outline)
-					)
-				)
-			)
-			(symbol "C_Polarized_1_1"
-				(pin passive line
-					(at 0 3.81 270)
-					(length 2.794)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -3.81 90)
-					(length 2.794)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
 		(symbol "Device:FerriteBead"
 			(pin_numbers
 				(hide yes)
@@ -2191,12 +2030,12 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "Interface_USB:FT201XS"
+		(symbol "FTDI:FT260S"
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
 			(property "Reference" "U"
-				(at -13.97 15.24 0)
+				(at 3.81 27.686 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2204,8 +2043,8 @@
 					(justify left)
 				)
 			)
-			(property "Value" "FT201XS"
-				(at 7.62 15.24 0)
+			(property "Value" "FT260S"
+				(at 4.064 25.4 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2213,8 +2052,8 @@
 					(justify left)
 				)
 			)
-			(property "Footprint" "Package_SO:SSOP-16_3.9x4.9mm_P0.635mm"
-				(at 25.4 -15.24 0)
+			(property "Footprint" "Package_SO:TSSOP-28_4.4x9.7mm_P0.65mm"
+				(at 0 -45.212 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2222,8 +2061,8 @@
 					(hide yes)
 				)
 			)
-			(property "Datasheet" "https://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT201X.pdf"
-				(at 0 0 0)
+			(property "Datasheet" "https://ftdichip.com/wp-content/uploads/2024/11/DS_FT260.pdf"
+				(at 0.508 -41.91 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2231,8 +2070,8 @@
 					(hide yes)
 				)
 			)
-			(property "Description" "Full Speed USB to I2C Bridge, SSOP-16"
-				(at 0 0 0)
+			(property "Description" "HID-class USB to UART/I2C Bridge IC"
+				(at 0 -48.26 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2240,67 +2079,29 @@
 					(hide yes)
 				)
 			)
-			(property "ki_keywords" "FTDI USB I2C Interface Converter"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "SSOP*3.9x4.9mm*P0.635mm*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "FT201XS_0_1"
+			(symbol "FT260S_1_1"
 				(rectangle
-					(start -13.97 13.97)
-					(end 13.97 -13.97)
+					(start -19.05 24.13)
+					(end 19.05 -24.13)
 					(stroke
-						(width 0.254)
-						(type default)
+						(width 0)
+						(type solid)
 					)
 					(fill
 						(type background)
 					)
 				)
-			)
-			(symbol "FT201XS_1_1"
 				(pin power_out line
-					(at -17.78 10.16 0)
-					(length 3.81)
-					(name "3V3OUT"
+					(at -21.59 21.59 0)
+					(length 2.54)
+					(name "VCC3V3"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at -17.78 2.54 0)
-					(length 3.81)
-					(name "USBDM"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "9"
+					(number "26"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2309,9 +2110,81 @@
 					)
 				)
 				(pin bidirectional line
-					(at -17.78 0 0)
-					(length 3.81)
-					(name "USBDP"
+					(at -21.59 16.51 0)
+					(length 2.54)
+					(name "DEBUGGER"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 10.16 0)
+					(length 2.54)
+					(name "STEST_RSTN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 7.62 0)
+					(length 2.54)
+					(name "RESETN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 3.81 0)
+					(length 2.54)
+					(name "VBUS_DET"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at -21.59 -3.81 0)
+					(length 2.54)
+					(name "DCNF0_I2C"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2327,34 +2200,16 @@
 					)
 				)
 				(pin input line
-					(at -17.78 -5.08 0)
-					(length 3.81)
-					(name "~{RESET}"
+					(at -21.59 -6.35 0)
+					(length 2.54)
+					(name "DCNF1_UART"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_in line
-					(at -2.54 17.78 270)
-					(length 3.81)
-					(name "VCC"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "12"
+					(number "9"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2362,35 +2217,17 @@
 						)
 					)
 				)
-				(pin power_in line
-					(at -2.54 -17.78 90)
-					(length 3.81)
-					(name "GND"
+				(pin bidirectional line
+					(at -21.59 -12.7 0)
+					(length 2.54)
+					(name "DM"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "5"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 2.54 17.78 270)
-					(length 3.81)
-					(name "VCCIO"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "3"
+					(number "24"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2398,17 +2235,17 @@
 						)
 					)
 				)
-				(pin power_in line
-					(at 2.54 -17.78 90)
-					(length 3.81)
-					(name "GND"
+				(pin bidirectional line
+					(at -21.59 -15.24 0)
+					(length 2.54)
+					(name "DP"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "13"
+					(number "25"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2417,34 +2254,16 @@
 					)
 				)
 				(pin input line
-					(at 17.78 10.16 180)
-					(length 3.81)
-					(name "SCL"
+					(at -21.59 -21.59 0)
+					(length 2.54)
+					(name "FSOURCE"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 17.78 7.62 180)
-					(length 3.81)
-					(name "SDA"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
+					(number "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2453,16 +2272,70 @@
 					)
 				)
 				(pin bidirectional line
-					(at 17.78 2.54 180)
-					(length 3.81)
-					(name "CBUS0"
+					(at -5.08 26.67 270)
+					(length 2.54)
+					(name "VCCIO"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "15"
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -26.67 90)
+					(length 2.54)
+					(name "AGND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 26.67 270)
+					(length 2.54)
+					(name "VCCIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -26.67 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2471,45 +2344,9 @@
 					)
 				)
 				(pin bidirectional line
-					(at 17.78 0 180)
-					(length 3.81)
-					(name "CBUS1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "14"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 17.78 -2.54 180)
-					(length 3.81)
-					(name "CBUS2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin bidirectional line
-					(at 17.78 -5.08 180)
-					(length 3.81)
-					(name "CBUS3"
+					(at 21.59 21.59 180)
+					(length 2.54)
+					(name "DIO5/SCL"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2525,16 +2362,16 @@
 					)
 				)
 				(pin bidirectional line
-					(at 17.78 -7.62 180)
-					(length 3.81)
-					(name "CBUS4"
+					(at 21.59 19.05 180)
+					(length 2.54)
+					(name "DIO6/SDA"
 						(effects
 							(font
 								(size 1.27 1.27)
 							)
 						)
 					)
-					(number "6"
+					(number "17"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2543,9 +2380,339 @@
 					)
 				)
 				(pin bidirectional line
-					(at 17.78 -10.16 180)
-					(length 3.81)
-					(name "CBUS5"
+					(at 21.59 16.51 180)
+					(length 2.54)
+					(name "DIO8/INTRIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 10.16 180)
+					(length 2.54)
+					(name "DIO3/RXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 7.62 180)
+					(length 2.54)
+					(name "DIO4/TXD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 3.81 180)
+					(length 2.54)
+					(name "DIO1/RTSN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 1.27 180)
+					(length 2.54)
+					(name "DIO2/CTSN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -1.27 180)
+					(length 2.54)
+					(name "DIO9/DTRN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -3.81 180)
+					(length 2.54)
+					(name "DIO10/DCD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -6.35 180)
+					(length 2.54)
+					(name "DIO11/RI"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -8.89 180)
+					(length 2.54)
+					(name "DIO13/GPIOH/DSRN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -12.7 180)
+					(length 2.54)
+					(name "DIO0/TX_ACT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -15.24 180)
+					(length 2.54)
+					(name "DIO12/BCD/RX_ACT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 21.59 -21.59 180)
+					(length 2.54)
+					(name "DIO7/#PWREN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Jumper:Jumper_2_Bridged"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "JP"
+				(at 0 1.905 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Jumper_2_Bridged"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Jumper, 2-pole, closed/bridged"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "Jumper SPST"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Jumper* TestPoint*2Pads* TestPoint*Bridge*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Jumper_2_Bridged_0_0"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Jumper_2_Bridged_0_1"
+				(arc
+					(start -1.524 0.254)
+					(mid 0 0.762)
+					(end 1.524 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "Jumper_2_Bridged_1_1"
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "A"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -2553,6 +2720,283 @@
 						)
 					)
 					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Jumper:SolderJumper_3_Bridged12"
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom no)
+			(on_board yes)
+			(property "Reference" "JP"
+				(at -2.54 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "SolderJumper_3_Bridged12"
+				(at 0 2.794 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "3-pole Solder Jumper, pins 1+2 closed/bridged"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "Solder Jumper SPDT"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "SolderJumper*Bridged12*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SolderJumper_3_Bridged12_0_1"
+				(polyline
+					(pts
+						(xy -2.54 0) (xy -2.032 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.016 1.016) (xy -1.016 -1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.016 0.508)
+					(end -0.508 -0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -1.016 -1.016)
+					(mid -2.0276 0)
+					(end -1.016 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -1.016 -1.016)
+					(mid -2.0276 0)
+					(end -1.016 1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -0.508 1.016)
+					(end 0.508 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -1.27) (xy 0 -1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start 1.016 1.016)
+					(mid 2.0276 0)
+					(end 1.016 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start 1.016 1.016)
+					(mid 2.0276 0)
+					(end 1.016 -1.016)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 1.016) (xy 1.016 -1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 0) (xy 2.032 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "SolderJumper_3_Bridged12_1_1"
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.54)
+					(name "C"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -3879,8 +4323,8 @@
 		(uuid 11abadf2-2d0f-4894-b608-b82294b7cc7d)
 	)
 	(rectangle
-		(start 78.74 157.48)
-		(end 115.57 194.31)
+		(start 243.84 19.05)
+		(end 280.67 55.88)
 		(stroke
 			(width 0)
 			(type default)
@@ -3903,8 +4347,8 @@
 		(uuid 3c20213f-b3a2-4dc1-a6f7-eb9734706f4d)
 	)
 	(rectangle
-		(start 173.99 17.78)
-		(end 242.57 68.58)
+		(start 16.51 120.65)
+		(end 81.28 171.45)
 		(stroke
 			(width 0)
 			(type default)
@@ -3915,8 +4359,8 @@
 		(uuid 615461d9-991a-4f63-ad57-e5af28a4a545)
 	)
 	(rectangle
-		(start 16.51 99.06)
-		(end 97.79 146.05)
+		(start 199.39 69.85)
+		(end 280.67 116.84)
 		(stroke
 			(width 0)
 			(type default)
@@ -3940,7 +4384,7 @@
 	)
 	(rectangle
 		(start 16.51 17.78)
-		(end 139.7 90.17)
+		(end 161.29 113.03)
 		(stroke
 			(width 0)
 			(type default)
@@ -3964,18 +4408,6 @@
 		(uuid baf8a862-61c9-4dbe-a38d-f8a306072c63)
 	)
 	(rectangle
-		(start 246.38 17.78)
-		(end 280.67 38.1)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(fill
-			(type none)
-		)
-		(uuid ccabd191-d20e-415e-9769-98c8807683d4)
-	)
-	(rectangle
 		(start 227.33 156.21)
 		(end 226.06 157.48)
 		(stroke
@@ -3989,8 +4421,8 @@
 		(uuid de9ca68c-15b8-402a-bcee-df846110cfd5)
 	)
 	(rectangle
-		(start 16.51 157.48)
-		(end 73.66 194.31)
+		(start 181.61 19.05)
+		(end 238.76 55.88)
 		(stroke
 			(width 0)
 			(type default)
@@ -4013,20 +4445,9 @@
 		)
 		(uuid fd1b10f8-37ec-40ba-a644-ea88a2cba3e8)
 	)
-	(text "RX"
+	(text "Secondary USB port output"
 		(exclude_from_sim no)
-		(at 274.32 31.75 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "021b11f0-abbb-4546-aaf0-beec3c7e729e")
-	)
-	(text "Secondary USB port"
-		(exclude_from_sim no)
-		(at 80.01 156.21 0)
+		(at 245.11 17.78 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4078,49 +4499,15 @@
 		)
 		(uuid "37eeba4c-1d32-4c68-b413-43ebe2e2c1c5")
 	)
-	(text "CBUS0 and CBUS3 \nuse default settings"
+	(text "EEPROM not needed\nwith default config"
 		(exclude_from_sim no)
-		(at 119.38 55.88 0)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "3a860001-f7ac-4f30-a622-affb526da089")
-	)
-	(text "UART UDPI connector"
-		(exclude_from_sim no)
-		(at 247.65 16.51 0)
+		(at 127 144.78 0)
 		(effects
 			(font
 				(size 1.27 1.27)
 			)
-			(justify left)
 		)
-		(uuid "463df83c-d3dc-4173-92b1-6f8957d54f1a")
-	)
-	(text "TX"
-		(exclude_from_sim no)
-		(at 274.32 26.67 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "48cca91e-a657-46f8-8d77-92f9a9c87ee8")
-	)
-	(text "GND"
-		(exclude_from_sim no)
-		(at 274.32 29.21 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left)
-		)
-		(uuid "55a194f6-8fbd-4268-bccb-9bb10f53f6dd")
+		(uuid "6cbb0dad-25a4-4e66-8730-b09c1c4b80b0")
 	)
 	(text "VDD"
 		(exclude_from_sim no)
@@ -4133,9 +4520,20 @@
 		)
 		(uuid "7f0b44d6-a466-40c5-84b3-7bfa9db69c97")
 	)
+	(text "VCCIN"
+		(exclude_from_sim no)
+		(at 93.98 101.6 0)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "8b0b856b-a45b-4c4a-8652-20343e903131")
+	)
 	(text "Internal USB 2.0 Port"
 		(exclude_from_sim no)
-		(at 17.78 156.21 0)
+		(at 182.88 17.78 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4156,7 +4554,7 @@
 	)
 	(text "FAN Connector"
 		(exclude_from_sim no)
-		(at 17.78 97.79 0)
+		(at 200.66 68.58 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4175,20 +4573,9 @@
 		)
 		(uuid "b304ae82-2a01-4d4d-b812-1ee2ab4738bc")
 	)
-	(text "CBUS1\ndefault\nTRISTATE"
-		(exclude_from_sim no)
-		(at 105.41 55.88 0)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "b5d70129-ed2f-47bd-90fb-a3dd9e5bc89a")
-	)
 	(text "https://www.frontx.com/cpx108_2.html"
 		(exclude_from_sim no)
-		(at 17.78 193.04 0)
+		(at 182.88 54.61 0)
 		(effects
 			(font
 				(size 1 1)
@@ -4199,7 +4586,7 @@
 	)
 	(text "MCU"
 		(exclude_from_sim no)
-		(at 175.26 16.51 0)
+		(at 16.51 119.38 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4221,7 +4608,7 @@
 	)
 	(text "https://noctua.at/pub/media/wysiwyg/Noctua_PWM_specifications_white_paper.pdf"
 		(exclude_from_sim no)
-		(at 17.78 144.78 0)
+		(at 200.66 115.57 0)
 		(effects
 			(font
 				(size 1 1)
@@ -4232,7 +4619,7 @@
 	)
 	(text "FTDI USB-I^{2}C Bridge"
 		(exclude_from_sim no)
-		(at 27.94 16.51 0)
+		(at 26.67 16.51 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -4240,50 +4627,103 @@
 		)
 		(uuid "e4e636e9-32d9-49a5-81ec-4b59aa47d57b")
 	)
+	(text "VCC3V3"
+		(exclude_from_sim no)
+		(at 104.14 101.6 0)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "f46e05f0-a128-4d48-9963-ce64ae447e77")
+	)
 	(junction
-		(at 73.66 115.57)
+		(at 271.78 106.68)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "02e872af-0ae4-4706-9bf1-ce5338434df4")
+	)
+	(junction
+		(at 256.54 86.36)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "0b1e628c-b374-4b4c-9b4e-34446c53b6c0")
 	)
 	(junction
-		(at 63.5 109.22)
+		(at 73.66 21.59)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0bc82bbd-1ad7-47c7-860e-c45ad6a7bed8")
+	)
+	(junction
+		(at 107.95 41.91)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "11cb26a5-46cc-41e2-9690-400b1e571679")
+	)
+	(junction
+		(at 246.38 80.01)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "138a95bf-b508-48a3-9ef6-4c02abfb890e")
 	)
 	(junction
-		(at 26.67 40.64)
+		(at 125.73 82.55)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "1a80c9b5-656b-4137-b572-5a6fa1a211e7")
+		(uuid "138e2d2c-b964-4cb6-9075-3c03fd8528b8")
 	)
 	(junction
-		(at 58.42 25.4)
+		(at 78.74 102.87)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "21932929-e30f-426c-8597-31ecb5b3f545")
+		(uuid "14b597c6-1cf0-437e-acce-6af0bb7194f5")
 	)
 	(junction
-		(at 106.68 46.99)
+		(at 138.43 82.55)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "243f4037-926c-4524-86ff-f187c2979c71")
+		(uuid "268772bf-82b7-4bd1-984f-7b219fa0f5ff")
 	)
 	(junction
-		(at 83.82 25.4)
+		(at 41.91 73.66)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "316d89ba-e669-4892-b93b-028720dacefd")
+		(uuid "2fb52a93-b3da-48c8-b5c5-9bcb156e36f1")
 	)
 	(junction
-		(at 43.18 54.61)
+		(at 110.49 53.34)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "425d37e3-a068-40fc-8da4-9b0249832b16")
+		(uuid "304db823-4007-4133-97f2-fee2a8585288")
 	)
 	(junction
-		(at 34.29 120.65)
+		(at 86.36 102.87)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "315e323d-f48b-4605-a3d8-74e22b8a9523")
+	)
+	(junction
+		(at 266.7 96.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "322e2609-a5c6-4ca2-a6c3-17d4746b2ef2")
+	)
+	(junction
+		(at 91.44 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "423bdc5a-0850-410a-b34e-ef2e789b9bc0")
+	)
+	(junction
+		(at 114.3 102.87)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4373e9c1-2ee3-401d-b4fd-b84e4d0fb290")
+	)
+	(junction
+		(at 217.17 91.44)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "43e6ddb9-9f53-4474-85af-ff14e53140f8")
@@ -4295,116 +4735,188 @@
 		(uuid "48496e91-20af-4436-8aae-ff8f5f8af9dd")
 	)
 	(junction
-		(at 118.11 59.69)
+		(at 104.14 39.37)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "4fab6cde-7bc3-4c16-8945-0faacc80d2ce")
+		(uuid "51b09549-49c7-4bbc-8d1d-b59557a86afc")
 	)
 	(junction
-		(at 49.53 123.19)
+		(at 20.32 60.96)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "5b452e20-254c-4356-a49c-da0dc3cb49d9")
+		(uuid "5c711473-354f-490c-abc4-85f7fff9f09d")
 	)
 	(junction
-		(at 26.67 30.48)
+		(at 91.44 102.87)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "65e849ee-2024-4627-a12f-c055aec3dba8")
+		(uuid "624edf07-13ba-4d8d-b451-260c56b17b79")
 	)
 	(junction
-		(at 58.42 44.45)
+		(at 55.88 21.59)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "6a3211f9-5563-4052-b51a-42bd0f95ca70")
+		(uuid "66b3f6b6-ce3e-49bf-949e-a627ec4e6a8f")
 	)
 	(junction
-		(at 81.28 74.93)
+		(at 55.88 39.37)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "6ffc23a3-bf89-4325-8405-18d07420c6f8")
+		(uuid "72c92c13-363d-4a73-a32f-8b6100aa7535")
 	)
 	(junction
-		(at 102.87 46.99)
+		(at 44.45 36.83)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "837b044c-6116-4555-a0da-8aef25c47f50")
+		(uuid "76e98d98-6b5f-4c0d-92f4-e17f9bd61e94")
 	)
 	(junction
-		(at 102.87 25.4)
+		(at 46.99 76.2)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "8620473c-441d-42e9-8fc9-529abd0406a0")
+		(uuid "8928476d-723b-4a8e-9bd7-b905e2fa141a")
 	)
 	(junction
-		(at 259.08 26.67)
+		(at 123.19 102.87)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "86775480-e6c1-4e34-b7d1-5c7af1d10abd")
+		(uuid "97617ab1-1ac1-4f73-b25a-41c9b295648b")
 	)
 	(junction
-		(at 125.73 59.69)
+		(at 101.6 102.87)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "9c9d98b6-6e72-4a1b-b4a5-1fbde9c2d6be")
+		(uuid "a0797b6f-4ffe-4f57-be60-f87a2b71655b")
 	)
 	(junction
-		(at 115.57 52.07)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "a0d2877b-f7ed-4112-b8bb-0b8c18f50a6d")
-	)
-	(junction
-		(at 46.99 135.89)
+		(at 229.87 106.68)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a3953df6-a63a-4169-89bc-d8ce6cb9697a")
 	)
 	(junction
-		(at 46.99 123.19)
+		(at 229.87 93.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a73758e4-f2bb-4f43-b1bf-f1b1c8cc8936")
 	)
 	(junction
-		(at 40.64 66.04)
+		(at 125.73 53.34)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "affbf5b0-08a0-483b-8a51-ae2170f9cc8c")
+		(uuid "b323c213-b156-4bcd-b274-3ceca0ff193b")
 	)
 	(junction
-		(at 106.68 25.4)
+		(at 48.26 21.59)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "c0778fe7-2095-40d4-b9c5-64a7d337e5df")
+		(uuid "b5f2ee15-43c4-4fa6-a0bb-74f031155d53")
 	)
 	(junction
-		(at 34.29 135.89)
+		(at 44.45 91.44)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b6164074-84db-4db7-a5a0-86a1fbaf47ad")
+	)
+	(junction
+		(at 73.66 102.87)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8bd1e9-5ede-426b-b280-3f69c10f52e5")
+	)
+	(junction
+		(at 107.95 21.59)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c47b46b3-cf55-4cfe-b221-0fa7b6fce3af")
+	)
+	(junction
+		(at 124.46 41.91)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c6b6fc8b-da00-4167-93fb-2f704d481c38")
+	)
+	(junction
+		(at 121.92 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c6cc169a-b055-454e-9875-bfce6b867a5c")
+	)
+	(junction
+		(at 138.43 21.59)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c90a8c21-675c-40c0-8f74-a5ca56ee51ad")
+	)
+	(junction
+		(at 101.6 92.71)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cfd890c6-2345-46d5-b13c-194c7870025a")
+	)
+	(junction
+		(at 214.63 93.98)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d304b7de-bcf6-4910-b146-10ab9d0e0f13")
+	)
+	(junction
+		(at 44.45 21.59)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d83556ca-8dd4-470f-b555-d4dbe0bf73b0")
+	)
+	(junction
+		(at 104.14 21.59)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e0b681e7-f6ab-453d-bfad-7dc611873782")
+	)
+	(junction
+		(at 144.78 82.55)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e242e073-4aef-4655-80fc-b71508fe29ce")
+	)
+	(junction
+		(at 217.17 106.68)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "e3546bb6-6976-416b-b4f0-ce70d4cc8c1d")
 	)
 	(junction
-		(at 38.1 52.07)
+		(at 200.66 35.56)
 		(diameter 0)
 		(color 0 0 0 0)
-		(uuid "ead31a0c-aea1-4876-a516-8597b70ac20f")
+		(uuid "f9b97adf-b3e4-4272-8a38-dea22680dff4")
 	)
 	(no_connect
-		(at 99.06 64.77)
-		(uuid "5216fa45-69bb-4499-a660-a1217d87c662")
-	)
-	(no_connect
-		(at 99.06 57.15)
-		(uuid "6bf67ad9-cf35-4e81-903d-3a3de53f1d35")
-	)
-	(no_connect
-		(at 99.06 62.23)
-		(uuid "7e3b226e-3086-42f5-b7f8-d60c0b6e8144")
+		(at 57.15 82.55)
+		(uuid "b441d631-a63e-48fa-b8e6-ff9bbda08e53")
 	)
 	(wire
 		(pts
-			(xy 31.75 173.99) (xy 36.83 173.99)
+			(xy 44.45 26.67) (xy 44.45 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0098c596-f018-4b85-9407-b75847188d85")
+	)
+	(wire
+		(pts
+			(xy 55.88 76.2) (xy 57.15 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "02417c31-6945-41f9-ae03-93cf55680ca0")
+	)
+	(wire
+		(pts
+			(xy 196.85 35.56) (xy 200.66 35.56)
 		)
 		(stroke
 			(width 0)
@@ -4414,7 +4926,7 @@
 	)
 	(wire
 		(pts
-			(xy 31.75 185.42) (xy 31.75 181.61)
+			(xy 196.85 46.99) (xy 196.85 43.18)
 		)
 		(stroke
 			(width 0)
@@ -4424,7 +4936,7 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 120.65) (xy 34.29 120.65)
+			(xy 209.55 91.44) (xy 217.17 91.44)
 		)
 		(stroke
 			(width 0)
@@ -4434,23 +4946,13 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 25.4) (xy 118.11 31.75)
+			(xy 128.27 44.45) (xy 128.27 45.72)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "06ce8179-81cd-4fe0-95da-99e09b1e31e5")
-	)
-	(wire
-		(pts
-			(xy 63.5 135.89) (xy 46.99 135.89)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "06e75e70-cb93-4ec9-8a25-354eee2d8d8d")
+		(uuid "0747aa23-c998-450b-97ad-d68a45c79707")
 	)
 	(wire
 		(pts
@@ -4464,17 +4966,17 @@
 	)
 	(wire
 		(pts
-			(xy 52.07 26.67) (xy 52.07 25.4)
+			(xy 271.78 105.41) (xy 271.78 106.68)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "09b7fc5f-ea2d-47db-922f-6aecef2cbe1e")
+		(uuid "09911be4-1111-4f55-8992-a13bbbf308e0")
 	)
 	(wire
 		(pts
-			(xy 238.76 58.42) (xy 238.76 60.96)
+			(xy 77.47 138.43) (xy 77.47 140.97)
 		)
 		(stroke
 			(width 0)
@@ -4484,7 +4986,27 @@
 	)
 	(wire
 		(pts
-			(xy 88.9 172.72) (xy 91.44 172.72)
+			(xy 40.64 45.72) (xy 40.64 46.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a6a354a-242e-441d-af9d-953ba1c6d0a4")
+	)
+	(wire
+		(pts
+			(xy 55.88 73.66) (xy 57.15 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d867e66-1b50-4ac6-83f3-dae6506036f9")
+	)
+	(wire
+		(pts
+			(xy 254 34.29) (xy 256.54 34.29)
 		)
 		(stroke
 			(width 0)
@@ -4504,7 +5026,37 @@
 	)
 	(wire
 		(pts
-			(xy 214.63 58.42) (xy 214.63 60.96)
+			(xy 125.73 82.55) (xy 138.43 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0fdde10c-0862-4b43-bce8-b644268b0f4f")
+	)
+	(wire
+		(pts
+			(xy 217.17 83.82) (xy 217.17 91.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0fe0c89b-4690-4d73-979c-fde7e4facb39")
+	)
+	(wire
+		(pts
+			(xy 114.3 102.87) (xy 123.19 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "100d5fbf-8783-4479-ae94-12ef2646b929")
+	)
+	(wire
+		(pts
+			(xy 53.34 161.29) (xy 53.34 163.83)
 		)
 		(stroke
 			(width 0)
@@ -4514,37 +5066,37 @@
 	)
 	(wire
 		(pts
-			(xy 259.08 26.67) (xy 267.97 26.67)
+			(xy 41.91 73.66) (xy 48.26 73.66)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "11494201-94db-4691-848c-366936e2e915")
+		(uuid "122bd24c-0dfc-419b-ac2c-357d04cb96d6")
 	)
 	(wire
 		(pts
-			(xy 40.64 66.04) (xy 40.64 67.31)
+			(xy 138.43 81.28) (xy 138.43 82.55)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "15273157-80fe-408c-a9d7-28e2a82f2a59")
+		(uuid "130d0d94-ee79-4a7d-aaa1-54e65f9a5d1a")
 	)
 	(wire
 		(pts
-			(xy 83.82 74.93) (xy 81.28 74.93)
+			(xy 110.49 53.34) (xy 113.03 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "17ba4bc0-84c2-4748-98d3-f654ff901c0c")
+		(uuid "17e9ced9-1aef-45e7-86fb-303aeed3fff9")
 	)
 	(wire
 		(pts
-			(xy 199.39 38.1) (xy 186.69 38.1)
+			(xy 38.1 140.97) (xy 27.94 140.97)
 		)
 		(stroke
 			(width 0)
@@ -4554,27 +5106,37 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 59.69) (xy 118.11 59.69)
+			(xy 107.95 41.91) (xy 124.46 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1a0ce9f1-062d-44cc-83a1-e5819eb9bb13")
+		(uuid "1b7e72de-4554-4f7b-8bf6-ae69985e5386")
 	)
 	(wire
 		(pts
-			(xy 102.87 25.4) (xy 102.87 31.75)
+			(xy 271.78 96.52) (xy 271.78 97.79)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1bb00feb-e98f-4877-ab05-c5fd9c54b54c")
+		(uuid "1bee3853-ffa1-42ed-9acb-6d8e26332623")
 	)
 	(wire
 		(pts
-			(xy 73.66 109.22) (xy 73.66 115.57)
+			(xy 34.29 57.15) (xy 34.29 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c44397e-fc0a-4023-9ce6-a8c4d8bd1d8f")
+	)
+	(wire
+		(pts
+			(xy 256.54 80.01) (xy 256.54 86.36)
 		)
 		(stroke
 			(width 0)
@@ -4584,7 +5146,7 @@
 	)
 	(wire
 		(pts
-			(xy 34.29 120.65) (xy 34.29 127)
+			(xy 217.17 91.44) (xy 217.17 97.79)
 		)
 		(stroke
 			(width 0)
@@ -4594,43 +5156,133 @@
 	)
 	(wire
 		(pts
-			(xy 68.58 171.45) (xy 68.58 173.99)
+			(xy 144.78 21.59) (xy 144.78 27.94)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1d3f3b9c-3c81-45ec-ad24-ddacc95ad944")
+		(uuid "1d8f1e85-6dcf-4858-be4a-94439c78f5f6")
 	)
 	(wire
 		(pts
-			(xy 106.68 25.4) (xy 106.68 31.75)
+			(xy 100.33 64.77) (xy 102.87 64.77)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "1ef2d2db-81c4-4dd7-88d9-addef7070a2c")
+		(uuid "1f2bfff3-43f9-4732-a21b-5d2fd7ecea66")
 	)
 	(wire
 		(pts
-			(xy 26.67 30.48) (xy 34.29 30.48)
+			(xy 100.33 41.91) (xy 107.95 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "26371a4c-1fff-4024-8d4f-9e7233942bcc")
+		(uuid "213c457e-e9c4-44f8-9475-f36016a68178")
 	)
 	(wire
 		(pts
-			(xy 33.02 54.61) (xy 43.18 54.61)
+			(xy 138.43 21.59) (xy 138.43 63.5)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "2cf059f6-d546-4260-b8a6-524538b3b35e")
+		(uuid "21a822b1-5989-468e-bbb1-84820b64197e")
+	)
+	(wire
+		(pts
+			(xy 124.46 38.1) (xy 124.46 41.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "224c988a-094a-4f89-9724-6b799440a625")
+	)
+	(wire
+		(pts
+			(xy 25.4 64.77) (xy 57.15 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "225b6033-da35-4887-89a0-c67c8265c3c3")
+	)
+	(wire
+		(pts
+			(xy 266.7 106.68) (xy 271.78 106.68)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22fdbb85-33d3-401a-ae11-af2dcc217ba3")
+	)
+	(wire
+		(pts
+			(xy 86.36 92.71) (xy 91.44 92.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24b4a255-dda6-420a-ac12-d59b82ab3d70")
+	)
+	(wire
+		(pts
+			(xy 100.33 39.37) (xy 104.14 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "25073930-7afd-46ea-bcbd-d5405994ced4")
+	)
+	(wire
+		(pts
+			(xy 54.61 57.15) (xy 57.15 57.15)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26127821-a0c2-450e-9f56-ef8ca2983f8c")
+	)
+	(wire
+		(pts
+			(xy 55.88 39.37) (xy 55.88 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "27e32d5e-0476-4213-b633-f37bfd84ad05")
+	)
+	(wire
+		(pts
+			(xy 123.19 101.6) (xy 123.19 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2c0cf1ba-9e8e-4e8d-8a92-bcf65f7cf3c0")
+	)
+	(wire
+		(pts
+			(xy 109.22 50.8) (xy 110.49 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2cc431ea-7d64-4c51-8292-c12d5c010259")
 	)
 	(wire
 		(pts
@@ -4644,7 +5296,27 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 179.07) (xy 60.96 179.07)
+			(xy 20.32 21.59) (xy 44.45 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d752e4f-c3a2-4865-9df6-9c33cd141dc4")
+	)
+	(wire
+		(pts
+			(xy 38.1 73.66) (xy 41.91 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2f0c80ac-906f-4bbd-8ecc-b377cc41ca9d")
+	)
+	(wire
+		(pts
+			(xy 222.25 40.64) (xy 226.06 40.64)
 		)
 		(stroke
 			(width 0)
@@ -4654,47 +5326,27 @@
 	)
 	(wire
 		(pts
-			(xy 102.87 39.37) (xy 102.87 46.99)
+			(xy 73.66 102.87) (xy 78.74 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "32435865-f7cf-49af-b0f3-4aa3e8548b21")
+		(uuid "3284f8e1-4f26-49c4-a36e-c49d07a75247")
 	)
 	(wire
 		(pts
-			(xy 104.14 68.58) (xy 104.14 71.12)
+			(xy 57.15 53.34) (xy 44.45 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "32869e31-a69a-44f2-ade4-ec94c42418ad")
+		(uuid "3781737c-3985-44d8-9958-9f6a61cac3b2")
 	)
 	(wire
 		(pts
-			(xy 52.07 36.83) (xy 52.07 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "376bed3b-f0d7-4ef4-b974-e44bc54058c4")
-	)
-	(wire
-		(pts
-			(xy 38.1 52.07) (xy 48.26 52.07)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "37f0e215-990f-4efd-a487-311bc8da478b")
-	)
-	(wire
-		(pts
-			(xy 34.29 120.65) (xy 38.1 120.65)
+			(xy 217.17 91.44) (xy 220.98 91.44)
 		)
 		(stroke
 			(width 0)
@@ -4704,17 +5356,7 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 166.37) (xy 147.32 166.37)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "3984a9f2-dcfb-47b6-b6d8-32977817a455")
-	)
-	(wire
-		(pts
-			(xy 26.67 125.73) (xy 63.5 125.73)
+			(xy 209.55 96.52) (xy 246.38 96.52)
 		)
 		(stroke
 			(width 0)
@@ -4724,57 +5366,27 @@
 	)
 	(wire
 		(pts
-			(xy 34.29 40.64) (xy 26.67 40.64)
+			(xy 44.45 91.44) (xy 46.99 91.44)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "3e75b3a7-4349-456a-bfe6-00604267511f")
+		(uuid "3cd56459-391c-438c-91aa-ed396db5dc10")
 	)
 	(wire
 		(pts
-			(xy 267.97 29.21) (xy 262.89 29.21)
+			(xy 78.74 31.75) (xy 78.74 34.29)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "444666a0-7a30-427c-a9a5-231455402222")
+		(uuid "3df884b2-3e15-4b6d-86ad-4a0df4efe377")
 	)
 	(wire
 		(pts
-			(xy 259.08 35.56) (xy 259.08 34.29)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "45ae70d2-3df9-42ef-95e8-87dfea0f7061")
-	)
-	(wire
-		(pts
-			(xy 55.88 52.07) (xy 63.5 52.07)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "47347af7-751c-4b87-a200-d4f578f3b8b4")
-	)
-	(wire
-		(pts
-			(xy 102.87 25.4) (xy 106.68 25.4)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "474b5feb-10ac-4ce4-85cc-b272c1b41276")
-	)
-	(wire
-		(pts
-			(xy 29.21 128.27) (xy 26.67 128.27)
+			(xy 212.09 99.06) (xy 209.55 99.06)
 		)
 		(stroke
 			(width 0)
@@ -4784,7 +5396,7 @@
 	)
 	(wire
 		(pts
-			(xy 29.21 135.89) (xy 29.21 128.27)
+			(xy 212.09 106.68) (xy 212.09 99.06)
 		)
 		(stroke
 			(width 0)
@@ -4794,7 +5406,7 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 182.88) (xy 99.06 187.96)
+			(xy 264.16 44.45) (xy 264.16 49.53)
 		)
 		(stroke
 			(width 0)
@@ -4804,17 +5416,37 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 39.37) (xy 118.11 59.69)
+			(xy 104.14 21.59) (xy 107.95 21.59)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "4c66a9f5-3a6d-4ea1-9877-77fdc2a5a296")
+		(uuid "4782495e-732a-439b-baf5-94c97fe9fea6")
 	)
 	(wire
 		(pts
-			(xy 63.5 109.22) (xy 63.5 110.49)
+			(xy 48.26 21.59) (xy 55.88 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4889dcb0-e39a-4dc8-af50-6fbb5c988191")
+	)
+	(wire
+		(pts
+			(xy 214.63 93.98) (xy 229.87 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4b5c54fd-e4e0-4daf-a398-0beb89a07047")
+	)
+	(wire
+		(pts
+			(xy 246.38 80.01) (xy 246.38 81.28)
 		)
 		(stroke
 			(width 0)
@@ -4824,7 +5456,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 45.72) (xy 186.69 45.72)
+			(xy 38.1 148.59) (xy 27.94 148.59)
 		)
 		(stroke
 			(width 0)
@@ -4834,37 +5466,77 @@
 	)
 	(wire
 		(pts
-			(xy 52.07 25.4) (xy 58.42 25.4)
+			(xy 20.32 21.59) (xy 20.32 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "4eb86bf7-054a-4d7f-96ca-bba22ec75605")
+		(uuid "4cf87cea-c5e4-4008-a77d-c5f95c5358f4")
 	)
 	(wire
 		(pts
-			(xy 266.7 31.75) (xy 266.7 35.56)
+			(xy 266.7 106.68) (xy 266.7 105.41)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "51911104-4c9e-49b0-8ae1-2a04a061a1e3")
+		(uuid "4d379108-c315-4ed8-8c0e-831ed279f028")
 	)
 	(wire
 		(pts
-			(xy 99.06 44.45) (xy 129.54 44.45)
+			(xy 123.19 91.44) (xy 123.19 93.98)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "531ff033-4776-4c75-97e4-bebb7e655705")
+		(uuid "4d3d60e2-c849-4612-a972-79132d7def5b")
 	)
 	(wire
 		(pts
-			(xy 49.53 118.11) (xy 49.53 123.19)
+			(xy 20.32 72.39) (xy 20.32 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d99bcfe-c98a-4e5b-aa42-4c6d21fef39b")
+	)
+	(wire
+		(pts
+			(xy 107.95 21.59) (xy 138.43 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e9a96ad-af74-4249-bd6a-c9baeeee5a15")
+	)
+	(wire
+		(pts
+			(xy 200.66 35.56) (xy 201.93 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4f4b6584-104f-4299-9992-b7051d5fefd9")
+	)
+	(wire
+		(pts
+			(xy 46.99 76.2) (xy 48.26 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50d62fc0-e384-4abf-947e-2d2453b5db06")
+	)
+	(wire
+		(pts
+			(xy 229.87 88.9) (xy 229.87 93.98)
 		)
 		(stroke
 			(width 0)
@@ -4874,27 +5546,7 @@
 	)
 	(wire
 		(pts
-			(xy 267.97 31.75) (xy 266.7 31.75)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "546e1675-2d5d-4d24-b78e-13db1c85a531")
-	)
-	(wire
-		(pts
-			(xy 104.14 78.74) (xy 104.14 80.01)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "54c5447a-2923-447c-b2e1-3478b80b5206")
-	)
-	(wire
-		(pts
-			(xy 31.75 181.61) (xy 36.83 181.61)
+			(xy 196.85 43.18) (xy 201.93 43.18)
 		)
 		(stroke
 			(width 0)
@@ -4904,17 +5556,47 @@
 	)
 	(wire
 		(pts
-			(xy 81.28 74.93) (xy 81.28 77.47)
+			(xy 114.3 101.6) (xy 114.3 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "5aefad0b-15c7-4a71-8729-b2b1f09f15ef")
+		(uuid "5a022d26-c520-4322-b13f-defe38b6f820")
 	)
 	(wire
 		(pts
-			(xy 26.67 30.48) (xy 26.67 31.75)
+			(xy 48.26 26.67) (xy 48.26 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a2e17b9-f707-4e36-8697-294e222540e1")
+	)
+	(wire
+		(pts
+			(xy 266.7 95.25) (xy 266.7 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5cb9b3b8-5f14-4ce2-8bbd-ba9ba6f6fe98")
+	)
+	(wire
+		(pts
+			(xy 44.45 21.59) (xy 48.26 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5cbe79db-0685-46ef-8d8a-78c24f50409c")
+	)
+	(wire
+		(pts
+			(xy 86.36 92.71) (xy 86.36 93.98)
 		)
 		(stroke
 			(width 0)
@@ -4924,17 +5606,17 @@
 	)
 	(wire
 		(pts
-			(xy 81.28 74.93) (xy 78.74 74.93)
+			(xy 104.14 21.59) (xy 104.14 26.67)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "5d3081be-3e41-4a6f-9b49-c908a91efe96")
+		(uuid "5d0d9ca0-6c91-482b-8f34-7497a3c9aa97")
 	)
 	(wire
 		(pts
-			(xy 88.9 175.26) (xy 91.44 175.26)
+			(xy 254 36.83) (xy 256.54 36.83)
 		)
 		(stroke
 			(width 0)
@@ -4944,47 +5626,107 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 25.4) (xy 58.42 25.4)
+			(xy 107.95 34.29) (xy 107.95 41.91)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "64e6e4d2-742c-4ee2-8f25-e375a343a7ee")
+		(uuid "5f5c2a41-d9e3-4eab-9e09-d370ed44cf74")
 	)
 	(wire
 		(pts
-			(xy 125.73 59.69) (xy 129.54 59.69)
+			(xy 123.19 69.85) (xy 123.19 83.82)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "65eddfbf-4a1c-4131-b594-6d3c05166137")
+		(uuid "5f777659-2c8c-4388-9f93-a3133d98d3fe")
 	)
 	(wire
 		(pts
-			(xy 106.68 46.99) (xy 129.54 46.99)
+			(xy 34.29 57.15) (xy 46.99 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "67685377-e90c-4a48-a010-c9955a115ea4")
+		(uuid "5ffd6750-f134-46e9-a6e2-73e5907f0d37")
 	)
 	(wire
 		(pts
-			(xy 55.88 54.61) (xy 63.5 54.61)
+			(xy 24.13 67.31) (xy 57.15 67.31)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "67d33e80-84e7-422c-bb18-2c2a0fb1661e")
+		(uuid "606f73ba-4c9f-4736-8e68-77e95b09bfd6")
 	)
 	(wire
 		(pts
-			(xy 63.5 120.65) (xy 63.5 125.73)
+			(xy 57.15 44.45) (xy 55.88 44.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60c4982d-8c22-4a03-b759-dbb0a427d387")
+	)
+	(wire
+		(pts
+			(xy 138.43 21.59) (xy 144.78 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62d975f1-b9cb-4ea7-8208-5f1b28d4e8a8")
+	)
+	(wire
+		(pts
+			(xy 125.73 81.28) (xy 125.73 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "63369abb-875c-4aaa-815b-8c9c2eea5aad")
+	)
+	(wire
+		(pts
+			(xy 41.91 73.66) (xy 41.91 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "691ac395-4161-4b97-8072-5ac856010cc7")
+	)
+	(wire
+		(pts
+			(xy 100.33 69.85) (xy 123.19 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "695a003e-c181-495b-871f-637651e56715")
+	)
+	(wire
+		(pts
+			(xy 101.6 101.6) (xy 101.6 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "697eb5a2-e094-47ac-98cf-42becb7cac3b")
+	)
+	(wire
+		(pts
+			(xy 246.38 91.44) (xy 246.38 96.52)
 		)
 		(stroke
 			(width 0)
@@ -4994,27 +5736,47 @@
 	)
 	(wire
 		(pts
-			(xy 104.14 60.96) (xy 104.14 54.61)
+			(xy 114.3 91.44) (xy 114.3 93.98)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "6dbc8fa4-1a36-4299-bf47-6fc1da5b7c3d")
+		(uuid "6baaaf40-904b-41cf-968f-1289fee2ed16")
 	)
 	(wire
 		(pts
-			(xy 115.57 52.07) (xy 115.57 60.96)
+			(xy 100.33 62.23) (xy 102.87 62.23)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "6eed1655-f166-4110-8dde-47011f6ecce4")
+		(uuid "6f02aaec-d673-4a7f-bb5d-3ef11811527e")
 	)
 	(wire
 		(pts
-			(xy 85.09 115.57) (xy 82.55 115.57)
+			(xy 44.45 36.83) (xy 44.45 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6fd0c517-315b-4ecd-84d1-f65b581f2e16")
+	)
+	(wire
+		(pts
+			(xy 144.78 82.55) (xy 149.86 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70b77866-9c46-43c1-b507-5c9710094321")
+	)
+	(wire
+		(pts
+			(xy 267.97 86.36) (xy 265.43 86.36)
 		)
 		(stroke
 			(width 0)
@@ -5034,27 +5796,17 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 46.99) (xy 102.87 46.99)
+			(xy 107.95 21.59) (xy 107.95 26.67)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "720a85bd-39d5-42ce-9238-b6ffb7e20540")
+		(uuid "72870ca2-c796-4f83-82a8-2f32882ac98e")
 	)
 	(wire
 		(pts
-			(xy 102.87 46.99) (xy 106.68 46.99)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "76eba2dd-a93f-455e-a324-52ef0aaedf8f")
-	)
-	(wire
-		(pts
-			(xy 60.96 184.15) (xy 57.15 184.15)
+			(xy 226.06 45.72) (xy 222.25 45.72)
 		)
 		(stroke
 			(width 0)
@@ -5064,7 +5816,7 @@
 	)
 	(wire
 		(pts
-			(xy 189.23 35.56) (xy 186.69 35.56)
+			(xy 29.21 138.43) (xy 27.94 138.43)
 		)
 		(stroke
 			(width 0)
@@ -5074,37 +5826,7 @@
 	)
 	(wire
 		(pts
-			(xy 58.42 59.69) (xy 58.42 44.45)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7aa51e95-67d1-4784-a08e-bfa17c9a8f45")
-	)
-	(wire
-		(pts
-			(xy 125.73 59.69) (xy 125.73 60.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7ac110ed-78dd-4399-a6d0-95057d575adc")
-	)
-	(wire
-		(pts
-			(xy 78.74 72.39) (xy 78.74 74.93)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "7ed0345c-ed4d-4d9a-9f2b-e57842385af8")
-	)
-	(wire
-		(pts
-			(xy 72.39 109.22) (xy 73.66 109.22)
+			(xy 255.27 80.01) (xy 256.54 80.01)
 		)
 		(stroke
 			(width 0)
@@ -5124,6 +5846,16 @@
 	)
 	(wire
 		(pts
+			(xy 91.44 102.87) (xy 101.6 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "80f56bf8-b94f-4fdd-ad20-cdd28ae6020e")
+	)
+	(wire
+		(pts
 			(xy 256.54 140.97) (xy 264.16 140.97)
 		)
 		(stroke
@@ -5134,7 +5866,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 35.56) (xy 196.85 35.56)
+			(xy 38.1 138.43) (xy 36.83 138.43)
 		)
 		(stroke
 			(width 0)
@@ -5144,13 +5876,13 @@
 	)
 	(wire
 		(pts
-			(xy 58.42 44.45) (xy 63.5 44.45)
+			(xy 125.73 53.34) (xy 128.27 53.34)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "8584e5c6-854b-4568-9ccf-a5a6c160ee48")
+		(uuid "855fc20f-932e-4731-a9ae-420532e86797")
 	)
 	(wire
 		(pts
@@ -5164,7 +5896,17 @@
 	)
 	(wire
 		(pts
-			(xy 73.66 115.57) (xy 74.93 115.57)
+			(xy 100.33 59.69) (xy 102.87 59.69)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8997c10a-4a26-4c36-a103-523b50db40b7")
+	)
+	(wire
+		(pts
+			(xy 256.54 86.36) (xy 257.81 86.36)
 		)
 		(stroke
 			(width 0)
@@ -5174,7 +5916,7 @@
 	)
 	(wire
 		(pts
-			(xy 214.63 25.4) (xy 214.63 27.94)
+			(xy 53.34 128.27) (xy 53.34 130.81)
 		)
 		(stroke
 			(width 0)
@@ -5194,7 +5936,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 48.26) (xy 186.69 48.26)
+			(xy 38.1 151.13) (xy 27.94 151.13)
 		)
 		(stroke
 			(width 0)
@@ -5204,7 +5946,7 @@
 	)
 	(wire
 		(pts
-			(xy 57.15 176.53) (xy 60.96 176.53)
+			(xy 222.25 38.1) (xy 226.06 38.1)
 		)
 		(stroke
 			(width 0)
@@ -5214,27 +5956,17 @@
 	)
 	(wire
 		(pts
-			(xy 259.08 35.56) (xy 266.7 35.56)
+			(xy 123.19 105.41) (xy 123.19 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "8c753782-a907-45b3-9821-a7b0eadd621b")
+		(uuid "8cb47025-f3ff-4ddf-a17d-87287eb39223")
 	)
 	(wire
 		(pts
-			(xy 46.99 123.19) (xy 49.53 123.19)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "8cb39fff-7bd8-49cb-840d-4f34e598352b")
-	)
-	(wire
-		(pts
-			(xy 106.68 185.42) (xy 106.68 187.96)
+			(xy 271.78 46.99) (xy 271.78 49.53)
 		)
 		(stroke
 			(width 0)
@@ -5244,17 +5976,17 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 52.07) (xy 115.57 52.07)
+			(xy 41.91 91.44) (xy 44.45 91.44)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "8f1b6517-861a-4350-98e5-45f279485725")
+		(uuid "8f2e8c2d-407c-4f49-94fe-e218fb68b55b")
 	)
 	(wire
 		(pts
-			(xy 34.29 30.48) (xy 34.29 31.75)
+			(xy 91.44 92.71) (xy 91.44 93.98)
 		)
 		(stroke
 			(width 0)
@@ -5264,17 +5996,17 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 189.23) (xy 147.32 189.23)
+			(xy 25.4 60.96) (xy 25.4 64.77)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "92f4bfab-ef8e-4342-adb6-2b2be5dbf194")
+		(uuid "9099f610-33fa-4975-ad39-fd67ce307af3")
 	)
 	(wire
 		(pts
-			(xy 101.6 185.42) (xy 106.68 185.42)
+			(xy 266.7 46.99) (xy 271.78 46.99)
 		)
 		(stroke
 			(width 0)
@@ -5284,27 +6016,37 @@
 	)
 	(wire
 		(pts
-			(xy 106.68 39.37) (xy 106.68 46.99)
+			(xy 57.15 50.8) (xy 48.26 50.8)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "952ab0dc-cbb1-4187-bc89-3dad6e499fd7")
+		(uuid "94e1c48a-174f-4127-989b-0add5ae0bfa9")
 	)
 	(wire
 		(pts
-			(xy 125.73 78.74) (xy 125.73 80.01)
+			(xy 46.99 76.2) (xy 46.99 83.82)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "956ace1e-18a0-483d-b3ad-f69b989fcb9a")
+		(uuid "962aea1d-88d2-40c3-ab38-f00ef4497c4f")
 	)
 	(wire
 		(pts
-			(xy 63.5 137.16) (xy 63.5 135.89)
+			(xy 73.66 21.59) (xy 104.14 21.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96364494-e779-43dd-a3d4-ea82387344b9")
+	)
+	(wire
+		(pts
+			(xy 271.78 109.22) (xy 271.78 106.68)
 		)
 		(stroke
 			(width 0)
@@ -5314,13 +6056,33 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 59.69) (xy 58.42 59.69)
+			(xy 86.36 102.87) (xy 91.44 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "9af991fe-91e7-4bb6-85cb-2b865806d93b")
+		(uuid "9a813545-9f70-4f80-9ce4-432ab0030c51")
+	)
+	(wire
+		(pts
+			(xy 48.26 50.8) (xy 48.26 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c5bc2cd-7bb5-4fa4-b23f-fd59c43c48b5")
+	)
+	(wire
+		(pts
+			(xy 138.43 71.12) (xy 138.43 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9ce0ac69-99bb-47f1-ac0b-cdd22251b885")
 	)
 	(wire
 		(pts
@@ -5334,23 +6096,33 @@
 	)
 	(wire
 		(pts
-			(xy 68.58 173.99) (xy 57.15 173.99)
+			(xy 55.88 44.45) (xy 55.88 39.37)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a1637134-6f48-4c67-b87b-d9ae67c7cb3d")
+		(uuid "a00207c3-d3f3-40ec-9953-82b1b9869a14")
 	)
 	(wire
 		(pts
-			(xy 106.68 25.4) (xy 118.11 25.4)
+			(xy 20.32 60.96) (xy 25.4 60.96)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a25aad44-dd28-40a4-a24e-084a845eaf17")
+		(uuid "a07febb7-f4eb-48b9-8371-b79bfea83f49")
+	)
+	(wire
+		(pts
+			(xy 266.7 97.79) (xy 266.7 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a13bd73b-5d85-4889-b81d-a1bfa293f5f3")
 	)
 	(wire
 		(pts
@@ -5364,7 +6136,7 @@
 	)
 	(wire
 		(pts
-			(xy 68.58 181.61) (xy 57.15 181.61)
+			(xy 233.68 43.18) (xy 222.25 43.18)
 		)
 		(stroke
 			(width 0)
@@ -5374,17 +6146,7 @@
 	)
 	(wire
 		(pts
-			(xy 33.02 52.07) (xy 38.1 52.07)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a4d8c172-9d10-4b93-abc4-716b9a18a630")
-	)
-	(wire
-		(pts
-			(xy 46.99 134.62) (xy 46.99 135.89)
+			(xy 229.87 105.41) (xy 229.87 106.68)
 		)
 		(stroke
 			(width 0)
@@ -5394,17 +6156,7 @@
 	)
 	(wire
 		(pts
-			(xy 43.18 54.61) (xy 48.26 54.61)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "a66ae0ad-2698-4677-8532-87d6ed5e9462")
-	)
-	(wire
-		(pts
-			(xy 63.5 109.22) (xy 64.77 109.22)
+			(xy 246.38 80.01) (xy 247.65 80.01)
 		)
 		(stroke
 			(width 0)
@@ -5414,7 +6166,7 @@
 	)
 	(wire
 		(pts
-			(xy 73.66 115.57) (xy 71.12 115.57)
+			(xy 256.54 86.36) (xy 254 86.36)
 		)
 		(stroke
 			(width 0)
@@ -5424,27 +6176,17 @@
 	)
 	(wire
 		(pts
-			(xy 115.57 52.07) (xy 129.54 52.07)
+			(xy 100.33 73.66) (xy 114.3 73.66)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "a7b1d5b4-f5ec-40b2-af7e-9886302d9b45")
+		(uuid "a8322e3e-534e-4bec-850e-08f144a9104b")
 	)
 	(wire
 		(pts
-			(xy 38.1 52.07) (xy 38.1 58.42)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "aa16404f-167c-4cf7-9c36-aeaaf3550b48")
-	)
-	(wire
-		(pts
-			(xy 26.67 40.64) (xy 26.67 41.91)
+			(xy 78.74 87.63) (xy 78.74 102.87)
 		)
 		(stroke
 			(width 0)
@@ -5454,7 +6196,7 @@
 	)
 	(wire
 		(pts
-			(xy 49.53 106.68) (xy 49.53 110.49)
+			(xy 229.87 77.47) (xy 229.87 81.28)
 		)
 		(stroke
 			(width 0)
@@ -5464,7 +6206,7 @@
 	)
 	(wire
 		(pts
-			(xy 86.36 163.83) (xy 86.36 167.64)
+			(xy 251.46 25.4) (xy 251.46 29.21)
 		)
 		(stroke
 			(width 0)
@@ -5474,7 +6216,7 @@
 	)
 	(wire
 		(pts
-			(xy 29.21 135.89) (xy 34.29 135.89)
+			(xy 212.09 106.68) (xy 217.17 106.68)
 		)
 		(stroke
 			(width 0)
@@ -5484,17 +6226,37 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 36.83) (xy 83.82 25.4)
+			(xy 144.78 35.56) (xy 144.78 82.55)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "ad88b024-e574-4c49-ba75-93765e6200fb")
+		(uuid "af068672-551f-447f-9fc5-fdac0924ca0b")
 	)
 	(wire
 		(pts
-			(xy 34.29 134.62) (xy 34.29 135.89)
+			(xy 200.66 33.02) (xy 223.52 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "af5ff99a-62ab-4ccb-b9a8-1babb1a42882")
+	)
+	(wire
+		(pts
+			(xy 57.15 39.37) (xy 55.88 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b0bd2f46-34aa-4ee8-9621-3554eacb0e3c")
+	)
+	(wire
+		(pts
+			(xy 217.17 105.41) (xy 217.17 106.68)
 		)
 		(stroke
 			(width 0)
@@ -5514,7 +6276,7 @@
 	)
 	(wire
 		(pts
-			(xy 238.76 48.26) (xy 238.76 50.8)
+			(xy 77.47 128.27) (xy 77.47 130.81)
 		)
 		(stroke
 			(width 0)
@@ -5524,33 +6286,83 @@
 	)
 	(wire
 		(pts
-			(xy 115.57 68.58) (xy 115.57 71.12)
+			(xy 104.14 34.29) (xy 104.14 39.37)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b307159b-3769-4141-b92f-cc1be9906cb2")
+		(uuid "b2a23bcb-3668-4c4f-ba11-c227cd883597")
 	)
 	(wire
 		(pts
-			(xy 78.74 34.29) (xy 78.74 36.83)
+			(xy 229.87 93.98) (xy 236.22 93.98)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "b407d5b0-bc7f-40d4-a801-ffd9aa74d2d6")
+		(uuid "b2b3d24f-a739-41b9-bade-39efb53bf3d3")
 	)
 	(wire
 		(pts
-			(xy 26.67 123.19) (xy 46.99 123.19)
+			(xy 100.33 50.8) (xy 101.6 50.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b37ed9ec-113d-4d90-a202-144bedcb368e")
+	)
+	(wire
+		(pts
+			(xy 223.52 35.56) (xy 222.25 35.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3cba3c7-3187-4160-9b1b-5cebc851094d")
+	)
+	(wire
+		(pts
+			(xy 44.45 34.29) (xy 44.45 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b5359458-8095-408a-9742-79c6775784f4")
+	)
+	(wire
+		(pts
+			(xy 209.55 93.98) (xy 214.63 93.98)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "b53aea3a-0d5f-4cea-9f02-b80dcab0890e")
+	)
+	(wire
+		(pts
+			(xy 73.66 21.59) (xy 73.66 34.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b749c95c-262a-4e16-94d7-03d357d4ebad")
+	)
+	(wire
+		(pts
+			(xy 110.49 50.8) (xy 110.49 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7848e13-cbb7-477e-a7ea-acb46d573b5f")
 	)
 	(wire
 		(pts
@@ -5564,7 +6376,7 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 43.18) (xy 186.69 43.18)
+			(xy 38.1 146.05) (xy 27.94 146.05)
 		)
 		(stroke
 			(width 0)
@@ -5574,7 +6386,7 @@
 	)
 	(wire
 		(pts
-			(xy 36.83 176.53) (xy 33.02 176.53)
+			(xy 201.93 38.1) (xy 198.12 38.1)
 		)
 		(stroke
 			(width 0)
@@ -5584,7 +6396,27 @@
 	)
 	(wire
 		(pts
-			(xy 101.6 182.88) (xy 101.6 185.42)
+			(xy 100.33 67.31) (xy 102.87 67.31)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb8be73c-89a2-4b53-8e55-f1223e60986c")
+	)
+	(wire
+		(pts
+			(xy 40.64 36.83) (xy 44.45 36.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bd6e4025-400b-4042-848c-a7e74eeb9e0b")
+	)
+	(wire
+		(pts
+			(xy 266.7 44.45) (xy 266.7 46.99)
 		)
 		(stroke
 			(width 0)
@@ -5594,17 +6426,17 @@
 	)
 	(wire
 		(pts
-			(xy 99.06 54.61) (xy 104.14 54.61)
+			(xy 223.52 33.02) (xy 223.52 35.56)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c186921d-1f2d-4c2e-b32d-7a709aa0baed")
+		(uuid "bf57f7a6-db59-45e0-ba7b-b973fef1e9d4")
 	)
 	(wire
 		(pts
-			(xy 34.29 135.89) (xy 46.99 135.89)
+			(xy 217.17 106.68) (xy 229.87 106.68)
 		)
 		(stroke
 			(width 0)
@@ -5614,23 +6446,33 @@
 	)
 	(wire
 		(pts
-			(xy 83.82 25.4) (xy 102.87 25.4)
+			(xy 114.3 73.66) (xy 114.3 83.82)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c7071e89-bd6d-4cd6-90bd-a318013274bf")
+		(uuid "c3cba562-1dc4-4232-b10a-bb9b773c619f")
 	)
 	(wire
 		(pts
-			(xy 49.53 123.19) (xy 53.34 123.19)
+			(xy 20.32 60.96) (xy 20.32 62.23)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "c76ce9b7-42a4-44f1-ba6c-8f4e8ad7ceaf")
+		(uuid "c4a848af-d2ea-43c7-b30a-023f0d929d66")
+	)
+	(wire
+		(pts
+			(xy 38.1 76.2) (xy 46.99 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c5ef34a9-b0b0-4736-a00f-2e102d4e4151")
 	)
 	(wire
 		(pts
@@ -5644,7 +6486,17 @@
 	)
 	(wire
 		(pts
-			(xy 46.99 127) (xy 46.99 123.19)
+			(xy 214.63 83.82) (xy 214.63 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9b0f1e8-9781-495f-b6f3-34ed486cfd97")
+	)
+	(wire
+		(pts
+			(xy 229.87 97.79) (xy 229.87 93.98)
 		)
 		(stroke
 			(width 0)
@@ -5654,7 +6506,7 @@
 	)
 	(wire
 		(pts
-			(xy 26.67 29.21) (xy 26.67 30.48)
+			(xy 101.6 91.44) (xy 101.6 92.71)
 		)
 		(stroke
 			(width 0)
@@ -5664,17 +6516,17 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 173.99) (xy 147.32 173.99)
+			(xy 91.44 92.71) (xy 101.6 92.71)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "cb25ebde-a34b-41d0-a68c-049dff3c6c46")
+		(uuid "ca6b43d8-4b22-4916-b864-27e6a092c32c")
 	)
 	(wire
 		(pts
-			(xy 36.83 179.07) (xy 33.02 179.07)
+			(xy 201.93 40.64) (xy 198.12 40.64)
 		)
 		(stroke
 			(width 0)
@@ -5694,6 +6546,26 @@
 	)
 	(wire
 		(pts
+			(xy 86.36 102.87) (xy 78.74 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd63d54b-e413-470b-a66b-5aa3fee896bf")
+	)
+	(wire
+		(pts
+			(xy 123.19 53.34) (xy 125.73 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdd8cb5f-4a7f-4af6-88ca-d595bb44da71")
+	)
+	(wire
+		(pts
 			(xy 199.39 144.145) (xy 199.39 139.065)
 		)
 		(stroke
@@ -5704,27 +6576,27 @@
 	)
 	(wire
 		(pts
-			(xy 254 26.67) (xy 259.08 26.67)
+			(xy 101.6 102.87) (xy 114.3 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "cf37f0cd-45ea-4110-8441-173af094880f")
+		(uuid "cfc1c924-5fcf-4340-ae40-680972a4d5b9")
 	)
 	(wire
 		(pts
-			(xy 43.18 54.61) (xy 43.18 58.42)
+			(xy 100.33 44.45) (xy 128.27 44.45)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d006230f-4eb5-4afb-a3c7-9b600fe0dc0c")
+		(uuid "cfd10a12-9fd0-4726-b117-b0a12cd35878")
 	)
 	(wire
 		(pts
-			(xy 86.36 167.64) (xy 91.44 167.64)
+			(xy 251.46 29.21) (xy 256.54 29.21)
 		)
 		(stroke
 			(width 0)
@@ -5734,17 +6606,17 @@
 	)
 	(wire
 		(pts
-			(xy 40.64 66.04) (xy 43.18 66.04)
+			(xy 229.87 106.68) (xy 229.87 109.22)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d2ca0807-592e-4af6-938d-8cb85e666b6a")
+		(uuid "d5c0eeb7-a341-4dd7-b9b1-3c491c7a9763")
 	)
 	(wire
 		(pts
-			(xy 31.75 172.72) (xy 31.75 173.99)
+			(xy 196.85 34.29) (xy 196.85 35.56)
 		)
 		(stroke
 			(width 0)
@@ -5754,7 +6626,7 @@
 	)
 	(wire
 		(pts
-			(xy 63.5 106.68) (xy 63.5 109.22)
+			(xy 246.38 77.47) (xy 246.38 80.01)
 		)
 		(stroke
 			(width 0)
@@ -5764,27 +6636,77 @@
 	)
 	(wire
 		(pts
-			(xy 125.73 68.58) (xy 125.73 71.12)
+			(xy 100.33 82.55) (xy 125.73 82.55)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "d85ff64f-a00a-420e-840c-22fbf7e62603")
+		(uuid "d77c03e9-7ece-4f28-8178-881da19ccaff")
 	)
 	(wire
 		(pts
-			(xy 38.1 66.04) (xy 40.64 66.04)
+			(xy 121.92 38.1) (xy 121.92 39.37)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "eb181cec-a98b-4800-8a50-59e312efbe21")
+		(uuid "d841bbbd-e8e8-42cb-8f73-fa53a1299570")
 	)
 	(wire
 		(pts
-			(xy 60.96 185.42) (xy 60.96 184.15)
+			(xy 200.66 35.56) (xy 200.66 33.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9e6ce3e-045f-4318-93bb-64ddffda8841")
+	)
+	(wire
+		(pts
+			(xy 100.33 53.34) (xy 110.49 53.34)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e09675e7-3d7a-4d22-b847-184400925116")
+	)
+	(wire
+		(pts
+			(xy 138.43 82.55) (xy 144.78 82.55)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea541b20-9575-4a8a-806f-539339774b99")
+	)
+	(wire
+		(pts
+			(xy 100.33 76.2) (xy 104.14 76.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ebec3f82-8b9e-4c86-8254-2234bf34834a")
+	)
+	(wire
+		(pts
+			(xy 121.92 39.37) (xy 128.27 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec443b89-c0cb-4efe-9e42-f56f6edb6ffe")
+	)
+	(wire
+		(pts
+			(xy 226.06 46.99) (xy 226.06 45.72)
 		)
 		(stroke
 			(width 0)
@@ -5794,7 +6716,17 @@
 	)
 	(wire
 		(pts
-			(xy 31.75 163.83) (xy 31.75 165.1)
+			(xy 40.64 36.83) (xy 40.64 38.1)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec65d25f-5a5c-4a86-9105-ad1083532b91")
+	)
+	(wire
+		(pts
+			(xy 196.85 25.4) (xy 196.85 26.67)
 		)
 		(stroke
 			(width 0)
@@ -5804,13 +6736,23 @@
 	)
 	(wire
 		(pts
-			(xy 118.11 59.69) (xy 125.73 59.69)
+			(xy 44.45 91.44) (xy 44.45 92.71)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "ee031dd5-ccea-493b-ac5c-6760dbfab492")
+		(uuid "ed7b10d0-72e5-43bf-9e80-fa264bf5b7b5")
+	)
+	(wire
+		(pts
+			(xy 104.14 39.37) (xy 121.92 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee9876b7-31b7-4760-9562-3aa3dac9fdc9")
 	)
 	(wire
 		(pts
@@ -5824,37 +6766,67 @@
 	)
 	(wire
 		(pts
-			(xy 143.51 181.61) (xy 147.32 181.61)
+			(xy 100.33 57.15) (xy 102.87 57.15)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f100b908-9bdb-4ba9-9a39-16c42048b982")
+		(uuid "f43527f8-d19e-4ead-bf77-430236d1eb0a")
 	)
 	(wire
 		(pts
-			(xy 115.57 78.74) (xy 115.57 80.01)
+			(xy 20.32 102.87) (xy 73.66 102.87)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f23539b2-4f8b-4555-98dd-a423cc0a72f3")
+		(uuid "f4b193bd-7625-4cc4-bf63-f61c44d19be5")
 	)
 	(wire
 		(pts
-			(xy 83.82 72.39) (xy 83.82 74.93)
+			(xy 55.88 21.59) (xy 73.66 21.59)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
-		(uuid "f2caec07-2b5a-4dbf-a4c6-05fb6e698036")
+		(uuid "f566a355-5c14-435c-b085-990db853058d")
 	)
 	(wire
 		(pts
-			(xy 68.58 185.42) (xy 68.58 181.61)
+			(xy 73.66 87.63) (xy 73.66 102.87)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f73987ad-093a-475f-b0ea-175a2197f51c")
+	)
+	(wire
+		(pts
+			(xy 124.46 41.91) (xy 128.27 41.91)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f83b0f9f-3e36-4144-8ee5-7f8839fcef32")
+	)
+	(wire
+		(pts
+			(xy 266.7 96.52) (xy 271.78 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8cf207f-dfb5-4ac4-b3f0-c5b6cb79b5d9")
+	)
+	(wire
+		(pts
+			(xy 233.68 46.99) (xy 233.68 43.18)
 		)
 		(stroke
 			(width 0)
@@ -5864,7 +6836,17 @@
 	)
 	(wire
 		(pts
-			(xy 199.39 40.64) (xy 186.69 40.64)
+			(xy 101.6 92.71) (xy 101.6 93.98)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fbe09a7c-0df2-4f19-995d-2915132f392b")
+	)
+	(wire
+		(pts
+			(xy 38.1 143.51) (xy 27.94 143.51)
 		)
 		(stroke
 			(width 0)
@@ -5874,17 +6856,7 @@
 	)
 	(wire
 		(pts
-			(xy 58.42 25.4) (xy 58.42 44.45)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "ff4d0e56-8fd1-4ed3-9bf2-20a2eb320295")
-	)
-	(wire
-		(pts
-			(xy 26.67 39.37) (xy 26.67 40.64)
+			(xy 86.36 101.6) (xy 86.36 102.87)
 		)
 		(stroke
 			(width 0)
@@ -5894,7 +6866,7 @@
 	)
 	(wire
 		(pts
-			(xy 34.29 39.37) (xy 34.29 40.64)
+			(xy 91.44 101.6) (xy 91.44 102.87)
 		)
 		(stroke
 			(width 0)
@@ -5904,29 +6876,7 @@
 	)
 	(global_label "SDA"
 		(shape bidirectional)
-		(at 129.54 46.99 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "0075edae-a6ce-48e4-8eea-8eba0d7f8b87")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 135.5748 46.99 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "SDA"
-		(shape bidirectional)
-		(at 186.69 38.1 180)
+		(at 27.94 140.97 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5936,7 +6886,7 @@
 		)
 		(uuid "00a56c56-96ec-42c7-a48c-4b4e4032eaab")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 180.6552 38.1 0)
+			(at 21.9052 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5948,7 +6898,7 @@
 	)
 	(global_label "USB2-"
 		(shape bidirectional)
-		(at 88.9 175.26 180)
+		(at 254 36.83 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5958,51 +6908,7 @@
 		)
 		(uuid "0218a704-c557-46f0-804e-2efb27db7372")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 80.4842 175.26 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "USB2-"
-		(shape bidirectional)
-		(at 60.96 176.53 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "1ce20452-17a1-4ab0-b90c-73784bd67ff4")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 69.3758 176.53 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "PWM"
-		(shape output)
-		(at 186.69 43.18 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "203bbef8-25f0-489e-be56-366030bd0b3c")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 181.0539 43.18 0)
+			(at 245.5842 36.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6014,7 +6920,7 @@
 	)
 	(global_label "USB1+"
 		(shape bidirectional)
-		(at 33.02 54.61 180)
+		(at 38.1 76.2 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6022,9 +6928,75 @@
 			)
 			(justify right)
 		)
-		(uuid "2120fb8b-fb2b-4c23-a50d-3e77cc95c748")
+		(uuid "10b9f4a8-28d5-4226-b1fe-0ac2e3c27471")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 24.6042 54.61 0)
+			(at 29.6842 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "UDPI"
+		(shape bidirectional)
+		(at 128.27 53.34 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "1999e298-1ee5-4ab6-ba9b-57d399230495")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 135.0191 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "USB2-"
+		(shape bidirectional)
+		(at 226.06 38.1 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "1ce20452-17a1-4ab0-b90c-73784bd67ff4")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 234.4758 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "PWM"
+		(shape output)
+		(at 27.94 146.05 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify right)
+		)
+		(uuid "203bbef8-25f0-489e-be56-366030bd0b3c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 22.3039 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6036,7 +7008,7 @@
 	)
 	(global_label "USB2+"
 		(shape bidirectional)
-		(at 60.96 179.07 0)
+		(at 226.06 40.64 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6046,7 +7018,161 @@
 		)
 		(uuid "2eed69d7-d0b2-4cb5-aaed-5ce3b6287be2")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 69.3758 179.07 0)
+			(at 234.4758 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "Tacho"
+		(shape output)
+		(at 236.22 93.98 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "36a0a670-a9f9-4bf1-8cb4-b5889d75acf7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 242.9037 93.98 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "USB1+"
+		(shape bidirectional)
+		(at 198.12 40.64 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify right)
+		)
+		(uuid "4f317d5e-3953-44fa-a46d-2e812fdc50fa")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 189.7042 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "UDPI"
+		(shape bidirectional)
+		(at 27.94 138.43 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify right)
+		)
+		(uuid "5b6541de-4c8e-4cd6-8b90-a64151aec968")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 21.1909 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "PWM"
+		(shape input)
+		(at 220.98 91.44 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "5fcc78d4-d82a-46af-859f-4e70844b265f")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 226.6161 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "USB1-"
+		(shape bidirectional)
+		(at 38.1 73.66 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify right)
+		)
+		(uuid "69c48396-e446-4c3a-8c97-e3d8aae302e1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 29.6842 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "USB2+"
+		(shape bidirectional)
+		(at 254 34.29 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify right)
+		)
+		(uuid "6ecc8ac2-e943-47b2-af54-c20d50063a71")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 245.5842 34.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "PWREN#"
+		(shape input)
+		(at 267.97 86.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1 1)
+			)
+			(justify left)
+		)
+		(uuid "74e5eee9-e132-4f49-ae84-91a4f0b10187")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 276.4156 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6058,7 +7184,7 @@
 	)
 	(global_label "SDA"
 		(shape bidirectional)
-		(at 147.32 173.99 0)
+		(at 128.27 41.91 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6066,207 +7192,9 @@
 			)
 			(justify left)
 		)
-		(uuid "36016cc6-396d-4ccc-a046-10f7d724c657")
+		(uuid "aee73287-1d50-4c09-b4b5-fa253b039349")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 153.3548 173.99 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "Tacho"
-		(shape output)
-		(at 53.34 123.19 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "36a0a670-a9f9-4bf1-8cb4-b5889d75acf7")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 60.0237 123.19 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "Tacho"
-		(shape input)
-		(at 147.32 181.61 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "3e46de0b-8bfb-4283-b83f-fa30fc3326d0")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 154.0037 181.61 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "UDPI"
-		(shape bidirectional)
-		(at 254 26.67 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "48cbc4fc-dd0b-4eaf-aa25-a552b03320f5")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 247.2509 26.67 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "USB1+"
-		(shape bidirectional)
-		(at 33.02 179.07 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "4f317d5e-3953-44fa-a46d-2e812fdc50fa")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 24.6042 179.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "UDPI"
-		(shape bidirectional)
-		(at 186.69 35.56 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "5b6541de-4c8e-4cd6-8b90-a64151aec968")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 179.9409 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "SLEEP#"
-		(shape input)
-		(at 186.69 48.26 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "5ee832cf-c59a-42f0-8ac9-a0b8d57b4ede")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 178.7682 48.26 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "PWM"
-		(shape input)
-		(at 38.1 120.65 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "5fcc78d4-d82a-46af-859f-4e70844b265f")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 43.7361 120.65 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "USB2+"
-		(shape bidirectional)
-		(at 88.9 172.72 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "6ecc8ac2-e943-47b2-af54-c20d50063a71")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 80.4842 172.72 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "PWM"
-		(shape input)
-		(at 147.32 189.23 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "747da039-cc9e-4918-97f1-1c1393051118")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 152.9561 189.23 0)
+			(at 134.3048 41.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6278,73 +7206,29 @@
 	)
 	(global_label "PWREN#"
 		(shape input)
-		(at 85.09 115.57 0)
+		(at 27.94 151.13 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
 				(size 1 1)
 			)
-			(justify left)
+			(justify right)
 		)
-		(uuid "74e5eee9-e132-4f49-ae84-91a4f0b10187")
+		(uuid "b41ac6f3-1fc0-445f-b509-657c2d03ab0b")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 93.5356 115.57 0)
+			(at 19.4944 151.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "SLEEP#"
-		(shape output)
-		(at 129.54 52.07 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "a7c98f72-dc34-4eca-ab38-a244848d1ffb")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 137.4618 52.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "PWREN#"
-		(shape output)
-		(at 129.54 59.69 0)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify left)
-		)
-		(uuid "c1eed6a2-d836-4b2f-9989-89385c24eeb7")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 137.9856 59.69 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
+				(justify right)
 				(hide yes)
 			)
 		)
 	)
 	(global_label "SCL"
 		(shape bidirectional)
-		(at 186.69 40.64 180)
+		(at 27.94 143.51 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6354,29 +7238,7 @@
 		)
 		(uuid "c9947a12-ae42-4b4a-8ac7-62efab9e8733")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 180.7028 40.64 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-				(hide yes)
-			)
-		)
-	)
-	(global_label "USB1-"
-		(shape bidirectional)
-		(at 33.02 52.07 180)
-		(fields_autoplaced yes)
-		(effects
-			(font
-				(size 1 1)
-			)
-			(justify right)
-		)
-		(uuid "d53de880-f831-4432-962b-04b073252e4f")
-		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 24.6042 52.07 0)
+			(at 21.9528 143.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6388,7 +7250,7 @@
 	)
 	(global_label "SCL"
 		(shape bidirectional)
-		(at 129.54 44.45 0)
+		(at 128.27 39.37 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6396,9 +7258,9 @@
 			)
 			(justify left)
 		)
-		(uuid "ded5983f-ed00-4706-9225-ab0acc9d1d4f")
+		(uuid "d49289d1-605e-471a-a521-0c0b97855889")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 135.5272 44.45 0)
+			(at 134.2572 39.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6410,7 +7272,7 @@
 	)
 	(global_label "Tacho"
 		(shape input)
-		(at 186.69 45.72 180)
+		(at 27.94 148.59 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6420,7 +7282,7 @@
 		)
 		(uuid "e1d2f70f-5ebd-4f54-8886-b9fda320878f")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 180.0063 45.72 0)
+			(at 21.2563 148.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6430,9 +7292,9 @@
 			)
 		)
 	)
-	(global_label "SCL"
-		(shape bidirectional)
-		(at 147.32 166.37 0)
+	(global_label "PWREN#"
+		(shape output)
+		(at 149.86 82.55 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6440,9 +7302,9 @@
 			)
 			(justify left)
 		)
-		(uuid "eab29395-abc3-4825-ae66-03dfb9acbdd5")
+		(uuid "f8c2268e-3e75-4ad4-b44b-639c9f8335a5")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 153.3072 166.37 0)
+			(at 158.3056 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6454,7 +7316,7 @@
 	)
 	(global_label "USB1-"
 		(shape bidirectional)
-		(at 33.02 176.53 180)
+		(at 198.12 38.1 180)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -6464,7 +7326,7 @@
 		)
 		(uuid "fec11f0f-f836-4e05-a0b5-50cb7f9b1bbf")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 24.6042 176.53 0)
+			(at 189.7042 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6475,8 +7337,74 @@
 		)
 	)
 	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 214.63 83.82 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "073cb504-b612-4af7-84dc-c1950b9cb414")
+		(property "Reference" "TP8"
+			(at 213.233 81.7302 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "Tacho"
+			(at 213.233 79.3059 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
+			(at 219.71 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 219.71 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 214.63 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0eab4862-ec36-48f3-ac41-2d0e75d36161")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "TP8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:VBUS")
-		(at 238.76 48.26 0)
+		(at 77.47 128.27 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -6485,7 +7413,7 @@
 		(dnp no)
 		(uuid "07c0789e-fb7f-4336-8c74-764883fd2195")
 		(property "Reference" "#PWR034"
-			(at 238.76 52.07 0)
+			(at 77.47 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6494,7 +7422,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 238.76 44.1269 0)
+			(at 77.47 124.1369 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6502,7 +7430,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 238.76 48.26 0)
+			(at 77.47 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6511,7 +7439,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 238.76 48.26 0)
+			(at 77.47 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6520,7 +7448,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 238.76 48.26 0)
+			(at 77.47 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6541,34 +7469,35 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:C")
-		(at 43.18 62.23 0)
+		(lib_id "Connector:TestPoint")
+		(at 125.73 53.34 0)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "0f45f6d1-69d4-4ae1-b03b-3e278abc188c")
-		(property "Reference" "C8"
-			(at 46.101 61.0178 0)
+		(uuid "0cdf4c71-8592-4913-b85c-99c8b1530fa8")
+		(property "Reference" "TP5"
+			(at 124.333 55.4298 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(justify right)
 			)
 		)
-		(property "Value" "47p"
-			(at 46.101 63.4421 0)
+		(property "Value" "UDPI"
+			(at 124.333 57.8541 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(justify right)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 44.1452 66.04 0)
+		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
+			(at 130.81 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6577,7 +7506,73 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 43.18 62.23 0)
+			(at 130.81 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 125.73 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7128b045-bb33-404f-b315-93497288e78f")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "TP5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 101.6 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0e8103cd-92ad-4361-9377-3397dc7c02ca")
+		(property "Reference" "C16"
+			(at 104.521 96.5778 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100n"
+			(at 104.521 99.0021 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 102.5652 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 101.6 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6586,7 +7581,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 43.18 62.23 0)
+			(at 101.6 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6594,8 +7589,8 @@
 				(hide yes)
 			)
 		)
-		(property "Mouser No" "80-C0603C470K4HACTU"
-			(at 46.99 64.77 0)
+		(property "Mouser No" "963-TMK107BJ104MA-T"
+			(at 106.68 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6604,15 +7599,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "479f49ae-dd4c-407a-a6f0-6a3924437511")
+			(uuid "21f92c85-35fc-4b91-aca1-a488b35c64cb")
 		)
 		(pin "1"
-			(uuid "89a5bedf-c6fe-402d-9d8b-19ae5f44d4ce")
+			(uuid "bd798cf1-6966-48ca-a863-38bc02e2cc93")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "C8")
+					(reference "C16")
 					(unit 1)
 				)
 			)
@@ -6620,7 +7615,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 63.5 137.16 0)
+		(at 271.78 109.22 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6629,7 +7624,7 @@
 		(fields_autoplaced yes)
 		(uuid "16cde31c-1af7-4b0a-8ea5-e4a99649112b")
 		(property "Reference" "#PWR013"
-			(at 63.5 143.51 0)
+			(at 271.78 115.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6638,7 +7633,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 63.5 141.2931 0)
+			(at 271.78 113.3531 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6646,7 +7641,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 63.5 137.16 0)
+			(at 271.78 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6655,7 +7650,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 63.5 137.16 0)
+			(at 271.78 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6664,7 +7659,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 63.5 137.16 0)
+			(at 271.78 109.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6685,34 +7680,16 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:LED")
-		(at 125.73 64.77 90)
+		(lib_id "power:VBUS")
+		(at 78.74 31.75 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "1de0f034-8e00-4141-94c9-361ba0236ad7")
-		(property "Reference" "D2"
-			(at 128.651 65.1453 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "Active"
-			(at 128.651 67.5696 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
-			(at 125.73 64.77 0)
+		(uuid "17f60429-7025-4354-b121-9b5a5976d105")
+		(property "Reference" "#PWR036"
+			(at 78.74 35.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6720,8 +7697,16 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "~"
-			(at 125.73 64.77 0)
+		(property "Value" "VBUS"
+			(at 78.74 27.6169 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6729,8 +7714,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Light emitting diode"
-			(at 125.73 64.77 0)
+		(property "Datasheet" ""
+			(at 78.74 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6738,17 +7723,8 @@
 				(hide yes)
 			)
 		)
-		(property "Sim.Pins" "1=K 2=A"
-			(at 125.73 64.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Mouser No" "720-LTQ39GQ1S22515"
-			(at 123.19 68.58 0)
+		(property "Description" "Power symbol creates a global label with name \"VBUS\""
+			(at 78.74 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6757,15 +7733,82 @@
 			)
 		)
 		(pin "1"
-			(uuid "e248dd3c-ab0f-4a31-8d03-6f4bc393142f")
-		)
-		(pin "2"
-			(uuid "a5b0079b-d228-4188-9bd6-3634a1103f5f")
+			(uuid "caf0053b-cc85-4ee5-ad35-e85a2a2f8d09")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "D2")
+					(reference "#PWR036")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 105.41 50.8 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1a74d8ab-6913-4edd-b9ac-843c34cd85ec")
+		(property "Reference" "R22"
+			(at 106.6222 49.022 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "4k7"
+			(at 104.1979 49.022 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 105.41 49.022 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 105.41 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 105.41 50.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "b27bb287-7f25-4c40-9d8b-0b1329e343d2")
+		)
+		(pin "1"
+			(uuid "9f2b65d3-e984-4b9f-8d4b-07d7f2932cc9")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "R22")
 					(unit 1)
 				)
 			)
@@ -6773,7 +7816,7 @@
 	)
 	(symbol
 		(lib_id "Diode:SMF20A")
-		(at 46.99 130.81 270)
+		(at 229.87 101.6 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -6782,7 +7825,7 @@
 		(fields_autoplaced yes)
 		(uuid "1eee8e3d-7d62-4768-8abf-95e69f34a84f")
 		(property "Reference" "D4"
-			(at 49.022 130.1663 90)
+			(at 231.902 100.9563 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6791,7 +7834,7 @@
 			)
 		)
 		(property "Value" "SMF20A"
-			(at 49.022 132.0873 90)
+			(at 231.902 102.8773 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6800,7 +7843,7 @@
 			)
 		)
 		(property "Footprint" "Diode_SMD:D_SMF"
-			(at 41.91 130.81 0)
+			(at 224.79 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6809,7 +7852,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.vishay.com/doc?85881"
-			(at 46.99 129.54 0)
+			(at 229.87 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6818,7 +7861,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 46.99 130.81 0)
+			(at 229.87 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6827,7 +7870,7 @@
 			)
 		)
 		(property "MFR" "SMF20A"
-			(at 46.99 130.81 90)
+			(at 229.87 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6836,7 +7879,7 @@
 			)
 		)
 		(property "LCSC" "C151295"
-			(at 46.99 130.81 90)
+			(at 229.87 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6861,7 +7904,7 @@
 	)
 	(symbol
 		(lib_id "power:VBUS")
-		(at 214.63 25.4 0)
+		(at 53.34 128.27 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -6870,7 +7913,7 @@
 		(dnp no)
 		(uuid "22f46af9-98fb-499c-9bc8-0c36f57a488e")
 		(property "Reference" "#PWR030"
-			(at 214.63 29.21 0)
+			(at 53.34 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6879,7 +7922,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 214.63 21.2669 0)
+			(at 53.34 124.1369 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6887,7 +7930,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 214.63 25.4 0)
+			(at 53.34 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6896,7 +7939,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 214.63 25.4 0)
+			(at 53.34 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6905,7 +7948,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 214.63 25.4 0)
+			(at 53.34 128.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6926,17 +7969,84 @@
 		)
 	)
 	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 217.17 83.82 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "24635214-e520-480b-a70f-71005292e94f")
+		(property "Reference" "TP7"
+			(at 218.567 81.7302 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "PWM"
+			(at 218.567 79.3059 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
+			(at 212.09 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 212.09 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 217.17 83.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "14a4eb11-149e-4f65-a2b4-bf077713eeba")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "TP7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R")
-		(at 125.73 74.93 180)
+		(at 123.19 97.79 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "2a75c5da-0c18-4470-ae6d-cd2c21e904d4")
-		(property "Reference" "R8"
-			(at 127.508 73.7178 0)
+		(uuid "2a670c10-16d2-455f-92a8-910d8cd07ada")
+		(property "Reference" "R9"
+			(at 124.968 96.5778 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6945,7 +8055,7 @@
 			)
 		)
 		(property "Value" "2k2"
-			(at 127.508 76.1421 0)
+			(at 124.968 99.0021 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6954,7 +8064,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 127.508 74.93 90)
+			(at 124.968 97.79 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6963,7 +8073,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 125.73 74.93 0)
+			(at 123.19 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6972,7 +8082,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 125.73 74.93 0)
+			(at 123.19 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6981,15 +8091,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "a1375f49-bfbf-46b6-b3cb-6d2aa9091113")
+			(uuid "ecb14ef9-b81a-4def-bd90-7036dd9733ae")
 		)
 		(pin "1"
-			(uuid "687b9997-9bc2-4e96-9002-1aa436103a0b")
+			(uuid "5bff1c4a-43f5-48da-88e2-1fb601611e0b")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R8")
+					(reference "R9")
 					(unit 1)
 				)
 			)
@@ -6997,7 +8107,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x05_Pin")
-		(at 52.07 179.07 0)
+		(at 217.17 40.64 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7005,7 +8115,7 @@
 		(dnp no)
 		(uuid "2e69fc8b-8fa4-4765-b482-65a14214635f")
 		(property "Reference" "J2"
-			(at 52.07 167.7557 0)
+			(at 217.17 29.3257 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7013,7 +8123,7 @@
 			)
 		)
 		(property "Value" "UsbPortB"
-			(at 52.07 170.18 0)
+			(at 217.17 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7021,7 +8131,7 @@
 			)
 		)
 		(property "Footprint" "Connector_PinHeader_2.00mm:PinHeader_1x05_P2.00mm_Vertical"
-			(at 52.07 179.07 0)
+			(at 217.17 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7030,7 +8140,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 52.07 179.07 0)
+			(at 217.17 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7039,7 +8149,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x05, script generated"
-			(at 52.07 179.07 0)
+			(at 217.17 40.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7072,17 +8182,16 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 102.87 35.56 0)
-		(mirror x)
+		(lib_id "Device:LED")
+		(at 114.3 87.63 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "2fb6de34-8a57-4e66-88d7-fdd11f865663")
-		(property "Reference" "R6"
-			(at 101.092 34.3478 0)
+		(uuid "39a22881-4da1-40ef-9096-0d371fd1ae52")
+		(property "Reference" "D7"
+			(at 117.221 88.0053 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7090,8 +8199,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "1k"
-			(at 101.092 36.7721 0)
+		(property "Value" "UDPI"
+			(at 117.221 90.4296 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7099,8 +8208,8 @@
 				(justify right)
 			)
 		)
-		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 101.092 35.56 90)
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
+			(at 114.3 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7109,7 +8218,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 102.87 35.56 0)
+			(at 114.3 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7117,8 +8226,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Resistor"
-			(at 102.87 35.56 0)
+		(property "Description" "Light emitting diode"
+			(at 114.3 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7126,95 +8235,34 @@
 				(hide yes)
 			)
 		)
-		(pin "2"
-			(uuid "1bfa8884-0f9d-4713-8f12-c937877f8cff")
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "630-HSMC-C130"
+			(at 110.49 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
 		)
 		(pin "1"
-			(uuid "02414da3-00a3-4aba-a844-fe388eacf869")
+			(uuid "379c533b-e5de-4cf1-b9bf-1c38b39f6729")
+		)
+		(pin "2"
+			(uuid "2d6256ef-7cdc-44be-b1b4-1eebaa8e6e26")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R6")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:C_Polarized")
-		(at 26.67 35.56 0)
-		(mirror y)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "33ea8f69-89ab-430e-bd48-b639b4e65fdc")
-		(property "Reference" "C4"
-			(at 23.749 33.4588 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "4u7"
-			(at 23.749 35.8831 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 25.7048 39.37 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 26.67 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Polarized capacitor"
-			(at 26.67 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Mouser No" "963-MLASE168AB5475KT"
-			(at 12.7 38.1 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "7111786c-087d-4e6c-a55e-8d92d16be774")
-		)
-		(pin "2"
-			(uuid "b23ebc72-e725-4fae-be6a-70bcdfffec94")
-		)
-		(instances
-			(project ""
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "C4")
+					(reference "D7")
 					(unit 1)
 				)
 			)
@@ -7222,7 +8270,7 @@
 	)
 	(symbol
 		(lib_id "Device:FerriteBead")
-		(at 31.75 168.91 0)
+		(at 196.85 30.48 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -7231,7 +8279,7 @@
 		(dnp no)
 		(uuid "3c29d1d4-7fe5-4d80-979b-6730c4ecf4e0")
 		(property "Reference" "FB1"
-			(at 28.3464 167.647 0)
+			(at 193.4464 29.217 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7240,7 +8288,7 @@
 			)
 		)
 		(property "Value" "FerriteBead"
-			(at 28.3464 170.0713 0)
+			(at 193.4464 31.6413 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7249,7 +8297,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 33.528 168.91 90)
+			(at 198.628 30.48 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7258,7 +8306,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 31.75 168.91 0)
+			(at 196.85 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7267,7 +8315,7 @@
 			)
 		)
 		(property "Description" "Ferrite bead"
-			(at 31.75 168.91 0)
+			(at 196.85 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7276,7 +8324,7 @@
 			)
 		)
 		(property "Mouser No" "81-BLM18SG221TZ1D"
-			(at 31.75 168.91 0)
+			(at 196.85 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7301,7 +8349,7 @@
 	)
 	(symbol
 		(lib_id "power:VBUS")
-		(at 31.75 163.83 0)
+		(at 196.85 25.4 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -7310,7 +8358,7 @@
 		(dnp no)
 		(uuid "3c53cdbf-f0de-40c8-9360-d5f8df39de62")
 		(property "Reference" "#PWR01"
-			(at 31.75 167.64 0)
+			(at 196.85 29.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7319,7 +8367,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 31.75 159.6969 0)
+			(at 196.85 21.2669 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7327,7 +8375,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 31.75 163.83 0)
+			(at 196.85 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7336,7 +8384,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 31.75 163.83 0)
+			(at 196.85 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7345,7 +8393,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 31.75 163.83 0)
+			(at 196.85 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7366,8 +8414,81 @@
 		)
 	)
 	(symbol
+		(lib_id "Jumper:SolderJumper_3_Bridged12")
+		(at 20.32 67.31 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(uuid "3ca4e067-e4af-4a88-a3e3-6c251df64c35")
+		(property "Reference" "JP3"
+			(at 22.86 72.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "UART_EN"
+			(at 22.86 69.9657 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" ""
+			(at 20.32 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 20.32 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "3-pole Solder Jumper, pins 1+2 closed/bridged"
+			(at 20.32 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "3"
+			(uuid "9a2b4583-c4d5-4a7c-8e1a-3f6c1b29ac41")
+		)
+		(pin "2"
+			(uuid "0ad76151-3b8f-4b25-8652-55ffc71e550e")
+		)
+		(pin "1"
+			(uuid "ce134278-f607-407f-a194-dbb557c9826e")
+		)
+		(instances
+			(project ""
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "JP3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Diode:SMF20A")
-		(at 34.29 130.81 270)
+		(at 217.17 101.6 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7376,7 +8497,7 @@
 		(fields_autoplaced yes)
 		(uuid "410fe40b-cb2f-4a3b-b5f6-8e5b2de0b3cb")
 		(property "Reference" "D3"
-			(at 36.322 130.1663 90)
+			(at 219.202 100.9563 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7385,7 +8506,7 @@
 			)
 		)
 		(property "Value" "SMF20A"
-			(at 36.322 132.0873 90)
+			(at 219.202 102.8773 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7394,7 +8515,7 @@
 			)
 		)
 		(property "Footprint" "Diode_SMD:D_SMF"
-			(at 29.21 130.81 0)
+			(at 212.09 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7403,7 +8524,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.vishay.com/doc?85881"
-			(at 34.29 129.54 0)
+			(at 217.17 100.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7412,7 +8533,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 34.29 130.81 0)
+			(at 217.17 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7421,7 +8542,7 @@
 			)
 		)
 		(property "MFR" "SMF20A"
-			(at 34.29 130.81 90)
+			(at 217.17 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7430,7 +8551,7 @@
 			)
 		)
 		(property "LCSC" "C151295"
-			(at 34.29 130.81 90)
+			(at 217.17 101.6 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7454,8 +8575,318 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:R")
+		(at 52.07 73.66 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "41815a7c-4267-4752-9692-03f384408e0c")
+		(property "Reference" "R4"
+			(at 52.07 68.4995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "27R"
+			(at 52.07 70.9238 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 52.07 75.438 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 52.07 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 52.07 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "d9c42334-9755-401e-a7c4-48c323106bf7")
+		)
+		(pin "1"
+			(uuid "d47062a2-894b-4a54-b255-2473413a228c")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "R4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 50.8 57.15 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4384ee9d-ef94-4fdc-93bb-c45bf6e53de2")
+		(property "Reference" "R19"
+			(at 50.8 62.3105 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "5k1"
+			(at 50.8 59.8862 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 50.8 58.928 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 50.8 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 50.8 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a28ca1c8-e34a-415a-a5a5-5e5179827b0e")
+		)
+		(pin "1"
+			(uuid "e7d2053a-3cdc-4d7a-bbd5-a64b7ee65788")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "R19")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 123.19 87.63 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "478df526-5cf5-4960-9ca9-c79528725720")
+		(property "Reference" "D6"
+			(at 126.111 88.0053 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "Host"
+			(at 126.111 90.4296 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
+			(at 123.19 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 123.19 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 123.19 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 123.19 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "720-LTQ39GQ1S22515"
+			(at 120.65 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc5a62e0-19df-4a80-aab0-19f49fff0c95")
+		)
+		(pin "2"
+			(uuid "2f8036f9-a8d8-488e-b703-f177671d83a7")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 138.43 67.31 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4a613a23-dc21-4c10-af08-369a513759da")
+		(property "Reference" "D8"
+			(at 141.351 67.6853 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "EN"
+			(at 141.351 70.1096 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
+			(at 138.43 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 138.43 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 138.43 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 138.43 67.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "720-LTQ39GQ1S22515"
+			(at 135.89 71.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20b2af9c-11c0-4e48-b3cc-99335f813cd3")
+		)
+		(pin "2"
+			(uuid "0b1945e5-caa3-4cf7-a337-3d2f9b9a5039")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:VDD")
-		(at 63.5 106.68 0)
+		(at 246.38 77.47 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7464,7 +8895,7 @@
 		(fields_autoplaced yes)
 		(uuid "4ad1ac84-4f8c-47a7-b621-5b60b4a283c1")
 		(property "Reference" "#PWR014"
-			(at 63.5 110.49 0)
+			(at 246.38 81.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7473,7 +8904,7 @@
 			)
 		)
 		(property "Value" "VDD"
-			(at 63.5 102.5469 0)
+			(at 246.38 73.3369 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7481,7 +8912,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 63.5 106.68 0)
+			(at 246.38 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7490,7 +8921,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 63.5 106.68 0)
+			(at 246.38 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7499,7 +8930,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VDD\""
-			(at 63.5 106.68 0)
+			(at 246.38 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7521,7 +8952,7 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 49.53 114.3 0)
+		(at 229.87 85.09 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7530,7 +8961,7 @@
 		(fields_autoplaced yes)
 		(uuid "4deb52ea-1220-4243-9fc5-f5d9eadce5c4")
 		(property "Reference" "R1"
-			(at 51.308 113.0878 0)
+			(at 231.648 83.8778 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7539,7 +8970,7 @@
 			)
 		)
 		(property "Value" "2k2"
-			(at 51.308 115.5121 0)
+			(at 231.648 86.3021 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7548,7 +8979,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 47.752 114.3 90)
+			(at 228.092 85.09 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7557,7 +8988,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 49.53 114.3 0)
+			(at 229.87 85.09 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7566,7 +8997,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 49.53 114.3 0)
+			(at 229.87 85.09 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7591,32 +9022,33 @@
 	)
 	(symbol
 		(lib_id "Connector:TestPoint")
-		(at 143.51 166.37 90)
+		(at 121.92 38.1 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "53bc6052-26f2-4f8c-a542-a77d091c0925")
+		(uuid "4f344cb5-643c-4723-9dff-24863a6b3540")
 		(property "Reference" "TP1"
-			(at 140.208 161.5905 90)
+			(at 120.523 36.0102 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Value" "SCL"
-			(at 140.208 164.0148 90)
+			(at 120.523 33.5859 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
-			(at 143.51 161.29 0)
+			(at 127 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7625,7 +9057,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 143.51 161.29 0)
+			(at 127 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7634,7 +9066,7 @@
 			)
 		)
 		(property "Description" "test point"
-			(at 143.51 166.37 0)
+			(at 121.92 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7643,10 +9075,10 @@
 			)
 		)
 		(pin "1"
-			(uuid "92022f28-e373-45d2-a63e-84724cf2c8cb")
+			(uuid "70684c2b-400c-4f66-99fd-142d05617eb3")
 		)
 		(instances
-			(project ""
+			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
 					(reference "TP1")
 					(unit 1)
@@ -7655,8 +9087,152 @@
 		)
 	)
 	(symbol
+		(lib_id "power:VDD")
+		(at 266.7 95.25 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "51b26a4b-9fb0-49c9-8064-2c00f9abd5a3")
+		(property "Reference" "#PWR016"
+			(at 266.7 99.06 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VDD"
+			(at 266.7 91.1169 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 266.7 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 266.7 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"VDD\""
+			(at 266.7 95.25 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "38518170-7afa-4dc7-8ca4-400f8618dfb9")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "#PWR016")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 266.7 101.6 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "52c9d806-1083-4097-aa31-25066f0fb638")
+		(property "Reference" "C17"
+			(at 263.779 102.8122 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "4u7"
+			(at 263.779 100.3879 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 265.7348 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 266.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "963-TMK107BJ104MA-T"
+			(at 266.7 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "ba527679-6f1f-4571-8f8d-5a2d6be0d2b6")
+		)
+		(pin "1"
+			(uuid "033ba613-f481-43cc-bb99-42203bac675e")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "C17")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R")
-		(at 78.74 115.57 90)
+		(at 261.62 86.36 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -7666,7 +9242,7 @@
 		(fields_autoplaced yes)
 		(uuid "551f1eea-4e06-43d2-b0f5-c589dadd1397")
 		(property "Reference" "R11"
-			(at 78.74 110.4095 90)
+			(at 261.62 81.1995 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7674,7 +9250,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 78.74 112.8338 90)
+			(at 261.62 83.6238 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7682,7 +9258,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 78.74 113.792 90)
+			(at 261.62 84.582 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7691,7 +9267,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 78.74 115.57 0)
+			(at 261.62 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7700,7 +9276,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 78.74 115.57 0)
+			(at 261.62 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7725,7 +9301,7 @@
 	)
 	(symbol
 		(lib_id "MCU_Microchip_ATtiny:ATtiny202-SS")
-		(at 214.63 43.18 0)
+		(at 53.34 146.05 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -7734,7 +9310,7 @@
 		(dnp no)
 		(uuid "5594de7d-c1d6-4682-b412-f43717cc6003")
 		(property "Reference" "U3"
-			(at 203.2 29.21 0)
+			(at 41.91 132.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7743,7 +9319,7 @@
 			)
 		)
 		(property "Value" "ATtiny202-SS"
-			(at 212.09 43.18 0)
+			(at 50.8 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7752,7 +9328,7 @@
 			)
 		)
 		(property "Footprint" "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm"
-			(at 214.63 43.18 0)
+			(at 53.34 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7762,7 +9338,7 @@
 			)
 		)
 		(property "Datasheet" "http://ww1.microchip.com/downloads/en/DeviceDoc/ATtiny202-402-AVR-MCU-with-Core-Independent-Peripherals_and-picoPower-40001969A.pdf"
-			(at 214.63 43.18 0)
+			(at 53.34 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7771,7 +9347,7 @@
 			)
 		)
 		(property "Description" "20MHz, 2kB Flash, 128B SRAM, 64B EEPROM, SOIC-8"
-			(at 214.63 43.18 0)
+			(at 53.34 146.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7813,44 +9389,35 @@
 		)
 	)
 	(symbol
-		(lib_id "Connector:Conn_01x03_Pin")
-		(at 273.05 29.21 0)
-		(mirror y)
+		(lib_id "FTDI:FT260S")
+		(at 78.74 60.96 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "581cdc8f-a888-46b1-adef-f0f09ad81988")
-		(property "Reference" "J8"
-			(at 267.97 20.4357 0)
+		(fields_autoplaced yes)
+		(uuid "5806e464-6440-40f7-ab29-26f22a955f41")
+		(property "Reference" "U1"
+			(at 80.8833 32.8125 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
-		(property "Value" "UDPI UART"
-			(at 267.97 22.86 0)
+		(property "Value" "FT260S"
+			(at 80.8833 35.2368 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
-		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x03_P2.54mm_Vertical"
-			(at 273.05 29.21 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 273.05 29.21 0)
+		(property "Footprint" "Package_SO:TSSOP-28_4.4x9.7mm_P0.65mm"
+			(at 78.74 106.172 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7858,8 +9425,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Generic connector, single row, 01x03, script generated"
-			(at 273.05 29.21 0)
+		(property "Datasheet" "https://ftdichip.com/wp-content/uploads/2024/11/DS_FT260.pdf"
+			(at 79.248 102.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7867,19 +9434,103 @@
 				(hide yes)
 			)
 		)
-		(pin "1"
-			(uuid "407f1c09-59ad-49c9-a266-8c436733c6a0")
+		(property "Description" "HID-class USB to UART/I2C Bridge IC"
+			(at 78.74 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "16"
+			(uuid "fcc91286-c084-435d-9381-fb6d6415be0a")
+		)
+		(pin "15"
+			(uuid "d170db72-9d22-4ae9-970f-8dfb9a2e35e4")
+		)
+		(pin "23"
+			(uuid "dfd44500-6765-4506-bea6-93adf4630599")
+		)
+		(pin "18"
+			(uuid "c80a4651-e109-4915-a601-2dac9cbb7069")
+		)
+		(pin "27"
+			(uuid "39e4707b-47c6-4984-8289-b395a31d4f8a")
+		)
+		(pin "8"
+			(uuid "15956c21-9877-477a-950f-f5d880701646")
 		)
 		(pin "2"
-			(uuid "99c78462-8f0a-4109-9976-bd40fc08c3dd")
+			(uuid "3ebaf47c-0be1-414b-a5f9-b388ac0e89df")
+		)
+		(pin "20"
+			(uuid "cdc69ee1-7d4e-4d79-a473-b6770945a15d")
+		)
+		(pin "9"
+			(uuid "3aaa94ee-3370-4386-ac06-92fe93ead8c5")
+		)
+		(pin "24"
+			(uuid "3bf57cfc-4e1a-4fe2-a190-e84d9f0e7f43")
+		)
+		(pin "13"
+			(uuid "9dbaa8e0-3795-4226-98ad-d347e15e46aa")
+		)
+		(pin "1"
+			(uuid "b62b4107-edfd-4bc3-a5bc-477f61e78610")
+		)
+		(pin "14"
+			(uuid "3597011a-4279-47ec-9da0-c86e48f081bc")
+		)
+		(pin "17"
+			(uuid "b06856a0-7540-42fa-bda1-a7d07ff50d3d")
+		)
+		(pin "11"
+			(uuid "10f28246-b6cd-4755-9260-292bdda31bcc")
+		)
+		(pin "4"
+			(uuid "9ab72fe8-d1cd-4467-9d66-aff5c323754b")
+		)
+		(pin "5"
+			(uuid "cb36c9b5-9258-4f93-afb3-9afe8dff94cd")
+		)
+		(pin "26"
+			(uuid "98ad2f81-4ee6-4dbe-bd63-4854cc126ca1")
+		)
+		(pin "7"
+			(uuid "e51709f8-beec-41c8-9036-1409f558d0b9")
+		)
+		(pin "6"
+			(uuid "58626d06-7b68-4177-8543-829dbde56eb4")
+		)
+		(pin "28"
+			(uuid "99349c0a-3844-4ea6-b8bc-cc7afaa3bebb")
+		)
+		(pin "10"
+			(uuid "a5c11547-9f42-4bfa-b30e-6c74b25552b2")
 		)
 		(pin "3"
-			(uuid "94c774c4-aa03-4309-8e50-72ea78b7fb93")
+			(uuid "e3fb5c11-f9e9-4fe2-9907-3c69e57b7d4e")
+		)
+		(pin "22"
+			(uuid "16401fde-4d48-469a-af3f-5e6c45210dfa")
+		)
+		(pin "12"
+			(uuid "06ad736d-756b-423d-82e5-f8ec018f6723")
+		)
+		(pin "19"
+			(uuid "9435f645-2ed5-46d3-835d-665c43b9e19d")
+		)
+		(pin "21"
+			(uuid "862fb5c4-df98-414b-8aa3-ee0884527f92")
+		)
+		(pin "25"
+			(uuid "f9956a44-f160-4a78-910e-3f3a1fbe0838")
 		)
 		(instances
 			(project ""
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "J8")
+					(reference "U1")
 					(unit 1)
 				)
 			)
@@ -7887,7 +9538,7 @@
 	)
 	(symbol
 		(lib_id "power:VBUS")
-		(at 86.36 163.83 0)
+		(at 251.46 25.4 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7895,7 +9546,7 @@
 		(dnp no)
 		(uuid "58e9af6c-022e-4ba5-b291-6952f90f13a4")
 		(property "Reference" "#PWR021"
-			(at 86.36 167.64 0)
+			(at 251.46 29.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7904,7 +9555,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 86.36 159.6969 0)
+			(at 251.46 21.2669 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7912,7 +9563,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 86.36 163.83 0)
+			(at 251.46 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7921,7 +9572,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 86.36 163.83 0)
+			(at 251.46 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7930,7 +9581,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 86.36 163.83 0)
+			(at 251.46 25.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7952,7 +9603,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 68.58 185.42 0)
+		(at 233.68 46.99 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -7961,7 +9612,7 @@
 		(fields_autoplaced yes)
 		(uuid "59c0e231-7e79-45e8-b07e-14609dde59d9")
 		(property "Reference" "#PWR04"
-			(at 68.58 191.77 0)
+			(at 233.68 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7970,7 +9621,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 68.58 189.5531 0)
+			(at 233.68 51.1231 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7978,7 +9629,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 68.58 185.42 0)
+			(at 233.68 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7987,7 +9638,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 68.58 185.42 0)
+			(at 233.68 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7996,7 +9647,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 68.58 185.42 0)
+			(at 233.68 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8082,8 +9733,86 @@
 		)
 	)
 	(symbol
+		(lib_id "Device:C")
+		(at 40.64 41.91 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5b34fe92-0c3a-4650-b2d3-25156b5e73b7")
+		(property "Reference" "C14"
+			(at 37.719 43.1222 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "4u7"
+			(at 37.719 40.6979 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 39.6748 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 40.64 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 40.64 41.91 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "963-TMK107BJ104MA-T"
+			(at 40.64 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "36f9b83f-2a04-4c91-ab5a-f6622a3b8e82")
+		)
+		(pin "1"
+			(uuid "067191c4-a5c5-4cca-9b26-5ebe34760bb3")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "C14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
-		(at 31.75 185.42 0)
+		(at 196.85 46.99 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -8093,7 +9822,7 @@
 		(fields_autoplaced yes)
 		(uuid "5d0844ff-7b91-4c6f-bdae-ece30b022e45")
 		(property "Reference" "#PWR05"
-			(at 31.75 191.77 0)
+			(at 196.85 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8102,7 +9831,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 31.75 189.5531 0)
+			(at 196.85 51.1231 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8110,7 +9839,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 31.75 185.42 0)
+			(at 196.85 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8119,7 +9848,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 31.75 185.42 0)
+			(at 196.85 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8128,7 +9857,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 31.75 185.42 0)
+			(at 196.85 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8215,294 +9944,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 115.57 80.01 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "60d611ca-5baf-4c10-89fd-7dc39a019d43")
-		(property "Reference" "#PWR033"
-			(at 115.57 86.36 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 115.57 84.1431 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 115.57 80.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 115.57 80.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 115.57 80.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "c2cc73f4-05f0-4eda-b6c1-2651a5619dbc")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR033")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Connector:TestPoint")
-		(at 143.51 181.61 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "6bd768e6-766b-4b4b-982b-5882d04c43cd")
-		(property "Reference" "TP3"
-			(at 140.208 176.8305 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "PWM"
-			(at 140.208 179.2548 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
-			(at 143.51 176.53 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 143.51 176.53 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "test point"
-			(at 143.51 181.61 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "718c3c03-cd66-4f6b-833a-53e10343aaf9")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "TP3")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:LED")
-		(at 104.14 64.77 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "6c1d1df1-e27f-43b4-beee-e97752880ba5")
-		(property "Reference" "D1"
-			(at 107.061 65.1453 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "HostAct"
-			(at 107.061 67.5696 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
-			(at 104.14 64.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 104.14 64.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Light emitting diode"
-			(at 104.14 64.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Sim.Pins" "1=K 2=A"
-			(at 104.14 64.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Mouser No" "630-HSMC-C130"
-			(at 100.33 72.39 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "c6de37e3-bd15-4c20-8687-7754ef06066e")
-		)
-		(pin "2"
-			(uuid "4e48715d-190a-48c9-88cd-0f3b79053062")
-		)
-		(instances
-			(project ""
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "D1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 52.07 52.07 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "6c9a1df6-d435-4c7d-bc2c-710f60b2dcb9")
-		(property "Reference" "R2"
-			(at 52.07 46.9095 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Value" "27R"
-			(at 52.07 49.3338 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 52.07 53.848 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 52.07 52.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 52.07 52.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "04b4a5a6-4542-4500-8e45-eeaebd203310")
-		)
-		(pin "1"
-			(uuid "20210cdb-a3ca-4984-94d1-06c478008f8c")
-		)
-		(instances
-			(project ""
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Connector:USB_A")
-		(at 99.06 172.72 0)
+		(at 264.16 34.29 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -8512,7 +9955,7 @@
 		(fields_autoplaced yes)
 		(uuid "732f3373-8033-4af2-8641-6de5349861a8")
 		(property "Reference" "J7"
-			(at 104.902 171.5078 0)
+			(at 270.002 33.0778 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8521,7 +9964,7 @@
 			)
 		)
 		(property "Value" "USB_Out"
-			(at 104.902 173.9321 0)
+			(at 270.002 35.5021 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8530,7 +9973,7 @@
 			)
 		)
 		(property "Footprint" "Connector_USB:USB_A_Molex_105057_Vertical"
-			(at 95.25 173.99 0)
+			(at 260.35 35.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8539,7 +9982,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 95.25 173.99 0)
+			(at 260.35 35.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8548,7 +9991,7 @@
 			)
 		)
 		(property "Description" "USB Type A connector"
-			(at 99.06 172.72 0)
+			(at 264.16 34.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8582,7 +10025,7 @@
 	)
 	(symbol
 		(lib_id "power:GNDPWR")
-		(at 106.68 187.96 0)
+		(at 271.78 49.53 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8591,7 +10034,7 @@
 		(fields_autoplaced yes)
 		(uuid "73a37230-25ec-4ebf-83b2-b45946326592")
 		(property "Reference" "#PWR022"
-			(at 106.68 193.04 0)
+			(at 271.78 54.61 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8600,7 +10043,7 @@
 			)
 		)
 		(property "Value" "S-GND"
-			(at 106.553 191.6867 0)
+			(at 271.653 53.2567 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8608,7 +10051,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 106.68 189.23 0)
+			(at 271.78 50.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8617,7 +10060,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 106.68 189.23 0)
+			(at 271.78 50.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8626,7 +10069,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GNDPWR\" , global ground"
-			(at 106.68 187.96 0)
+			(at 271.78 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8648,7 +10091,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x04_Pin")
-		(at 41.91 176.53 0)
+		(at 207.01 38.1 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -8657,7 +10100,7 @@
 		(dnp no)
 		(uuid "7d924f3f-8596-461e-9c56-3846b4bb9d9d")
 		(property "Reference" "J1"
-			(at 41.91 167.64 0)
+			(at 207.01 29.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8665,7 +10108,7 @@
 			)
 		)
 		(property "Value" "UsbPortA"
-			(at 41.91 170.0643 0)
+			(at 207.01 31.6343 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8673,7 +10116,7 @@
 			)
 		)
 		(property "Footprint" "Connector_PinHeader_2.00mm:PinHeader_1x04_P2.00mm_Vertical"
-			(at 41.91 176.53 0)
+			(at 207.01 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8682,7 +10125,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 41.91 176.53 0)
+			(at 207.01 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8691,7 +10134,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x04, script generated"
-			(at 41.91 176.53 0)
+			(at 207.01 38.1 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8721,17 +10164,34 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 40.64 67.31 0)
+		(lib_id "Connector:TestPoint")
+		(at 104.14 76.2 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "855de27c-fb5d-44ab-ab6b-733a1602052f")
-		(property "Reference" "#PWR027"
-			(at 40.64 73.66 0)
+		(uuid "803b943f-26ce-499e-9a72-580fe120b85c")
+		(property "Reference" "TP6"
+			(at 105.537 78.2898 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "RX_ACT"
+			(at 105.537 80.7141 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
+			(at 99.06 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8739,16 +10199,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "GND"
-			(at 40.64 71.4431 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 40.64 67.31 0)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8756,17 +10208,8 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" ""
-			(at 40.64 67.31 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 40.64 67.31 0)
+		(property "Description" "test point"
+			(at 104.14 76.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8775,12 +10218,79 @@
 			)
 		)
 		(pin "1"
-			(uuid "e2baf61c-920f-41eb-97b0-b05cafd40eee")
+			(uuid "04a05390-dc19-4932-b500-7122aba61f91")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR027")
+					(reference "TP6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 124.46 38.1 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "850001ef-59c6-4cde-880f-5153d0dd94c0")
+		(property "Reference" "TP2"
+			(at 125.857 36.0102 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "SDA"
+			(at 125.857 33.5859 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
+			(at 119.38 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 124.46 38.1 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cf6da158-7ea2-44c2-869c-786728c1ede4")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "TP2")
 					(unit 1)
 				)
 			)
@@ -8854,7 +10364,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 99.06 187.96 0)
+		(at 264.16 49.53 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -8863,7 +10373,7 @@
 		(fields_autoplaced yes)
 		(uuid "8823a416-f4d2-4fdf-85b4-c122590387b4")
 		(property "Reference" "#PWR023"
-			(at 99.06 194.31 0)
+			(at 264.16 55.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8872,7 +10382,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 99.06 192.0931 0)
+			(at 264.16 53.6631 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8880,7 +10390,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 99.06 187.96 0)
+			(at 264.16 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8889,7 +10399,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 99.06 187.96 0)
+			(at 264.16 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8898,7 +10408,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 99.06 187.96 0)
+			(at 264.16 49.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8919,203 +10429,17 @@
 		)
 	)
 	(symbol
-		(lib_id "Interface_USB:FT201XS")
-		(at 81.28 54.61 0)
+		(lib_id "Device:R")
+		(at 144.78 31.75 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "8a128e9d-873f-43ea-b48f-d97410e1f148")
-		(property "Reference" "U2"
-			(at 85.9633 36.4955 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "FT201XS"
-			(at 85.9633 38.9198 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Package_SO:SSOP-16_3.9x4.9mm_P0.635mm"
-			(at 106.68 69.85 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "https://www.mouser.de/datasheet/2/163/DS_FT201X-3173.pdf"
-			(at 81.28 54.61 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Full Speed USB to I2C Bridge, SSOP-16"
-			(at 81.28 54.61 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Mouser No" "895-FT201XS-R"
-			(at 81.28 54.61 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "14"
-			(uuid "d13ab805-00d4-4d6f-b7f2-21aa3d9d3e1a")
-		)
-		(pin "7"
-			(uuid "da686016-f383-4e37-a112-f1215ec53d90")
-		)
-		(pin "16"
-			(uuid "72620cfe-c796-4968-8754-ab607bf219df")
-		)
-		(pin "2"
-			(uuid "68e2f081-c24d-4e26-a0f6-25f024406f87")
-		)
-		(pin "8"
-			(uuid "cee32688-0a65-48ed-b977-58da3301571b")
-		)
-		(pin "11"
-			(uuid "b811674f-d30c-486b-b002-75b32c077195")
-		)
-		(pin "5"
-			(uuid "713aca0d-9944-40ef-a93b-cfba2a885930")
-		)
-		(pin "15"
-			(uuid "d2e49c3e-46c6-4de5-aec9-901d4c66be6d")
-		)
-		(pin "12"
-			(uuid "421dac8d-fcf5-40c5-9682-2f7c43b8062e")
-		)
-		(pin "6"
-			(uuid "eea2ab21-95cf-4502-bdb3-04a76207175b")
-		)
-		(pin "4"
-			(uuid "0d343b8b-00be-4ea0-8618-a9f7e09d5be1")
-		)
-		(pin "3"
-			(uuid "f15cea31-f37a-46ad-861d-bffc2a00ad95")
-		)
-		(pin "13"
-			(uuid "de289a48-951a-4526-9695-be36662676f8")
-		)
-		(pin "10"
-			(uuid "4f6bcd5f-c0de-47e0-a0a0-1d2bab58bbec")
-		)
-		(pin "9"
-			(uuid "09d2d1af-033a-4a84-b3cc-3c42dc913102")
-		)
-		(pin "1"
-			(uuid "1857c32a-38ed-46b9-b5dd-d59748d6f403")
-		)
-		(instances
-			(project ""
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "U2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:VBUS")
-		(at 68.58 171.45 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "8a3bc1ab-d57c-4b41-9f8f-4d02c779c041")
-		(property "Reference" "#PWR02"
-			(at 68.58 175.26 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "VBUS"
-			(at 68.58 167.3169 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 68.58 171.45 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 68.58 171.45 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 68.58 171.45 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "6edc5449-0ae0-4e58-bc0a-c1783e938de2")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR02")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 259.08 30.48 0)
-		(mirror x)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "916cdd1d-db2f-46ee-bd80-de708575cf61")
-		(property "Reference" "R9"
-			(at 257.302 29.2678 0)
+		(uuid "8972549b-1ea8-448f-be80-c1ae042a5e4b")
+		(property "Reference" "R18"
+			(at 146.558 30.5378 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9123,8 +10447,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "4k7"
-			(at 257.302 31.6921 0)
+		(property "Value" "10k"
+			(at 146.558 32.9621 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9133,7 +10457,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 257.302 30.48 90)
+			(at 146.558 31.75 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9142,7 +10466,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 259.08 30.48 0)
+			(at 144.78 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9151,7 +10475,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 259.08 30.48 0)
+			(at 144.78 31.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9160,15 +10484,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "b0a2a840-b82b-414c-a87f-e72e65b266c6")
+			(uuid "d8376074-5db4-4e4e-8bea-4cda8a0ef77c")
 		)
 		(pin "1"
-			(uuid "2f848b5d-89e2-4109-a667-1b2e6bcd7934")
+			(uuid "f3167801-c9cf-4053-8761-a679dabf8f56")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R9")
+					(reference "R18")
 					(unit 1)
 				)
 			)
@@ -9176,32 +10500,34 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 52.07 54.61 90)
-		(mirror x)
+		(at 48.26 30.48 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "9275973e-b1eb-48d7-8289-e12045e2c612")
-		(property "Reference" "R3"
-			(at 52.07 59.7705 90)
+		(fields_autoplaced yes)
+		(uuid "8f621aed-610c-44ab-8e94-dd48a4766c51")
+		(property "Reference" "R20"
+			(at 50.038 29.2678 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
-		(property "Value" "27R"
-			(at 52.07 57.3462 90)
+		(property "Value" "10k"
+			(at 50.038 31.6921 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 52.07 52.832 90)
+			(at 50.038 30.48 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9210,7 +10536,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 52.07 54.61 0)
+			(at 48.26 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9219,7 +10545,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 52.07 54.61 0)
+			(at 48.26 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9228,48 +10554,50 @@
 			)
 		)
 		(pin "2"
-			(uuid "56004c69-27b7-430d-b13e-9d00a0c24290")
+			(uuid "2e20d6a5-a5a7-4396-8e81-2749cdb21b07")
 		)
 		(pin "1"
-			(uuid "f043fe7e-11cf-4944-bb58-4a7a997e8e82")
+			(uuid "23d7c77f-1f1e-4dd5-8b6d-8cc13a120a20")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R3")
+					(reference "R20")
 					(unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Connector:TestPoint")
-		(at 143.51 173.99 90)
+		(lib_id "Device:R")
+		(at 104.14 30.48 0)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "9329437e-a628-4dbd-90a2-333e7a5d9906")
-		(property "Reference" "TP2"
-			(at 140.208 169.2105 90)
+		(uuid "926ab8e6-09ac-48b5-b7f9-8fa1f5613d0a")
+		(property "Reference" "R15"
+			(at 102.362 29.2678 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
-		(property "Value" "SDA"
-			(at 140.208 171.6348 90)
+		(property "Value" "1k"
+			(at 102.362 31.6921 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify right)
 			)
 		)
-		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
-			(at 143.51 168.91 0)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 102.362 30.48 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9278,7 +10606,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 143.51 168.91 0)
+			(at 104.14 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9286,22 +10614,104 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "test point"
-			(at 143.51 173.99 0)
+		(property "Description" "Resistor"
+			(at 104.14 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(hide yes)
 			)
+		)
+		(pin "2"
+			(uuid "2b31d134-4d52-4ca9-9735-55db73be8eec")
 		)
 		(pin "1"
-			(uuid "5338970c-8e18-4ae5-9e8f-63f939bb5574")
+			(uuid "5e9b81d5-7c16-47c7-bd14-37724e66522d")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "TP2")
+					(reference "R15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 41.91 87.63 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "94c939ed-4017-4dec-af44-7fb4aad6668e")
+		(property "Reference" "C12"
+			(at 38.989 86.4178 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "47p"
+			(at 38.989 88.8421 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 40.9448 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 41.91 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 41.91 87.63 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "80-C0603C470K4HACTU"
+			(at 35.56 91.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "276d295b-ef78-442d-bac1-a940ec11ab07")
+		)
+		(pin "1"
+			(uuid "a04f81e7-1842-43dc-8242-1de9fac5f710")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "C12")
 					(unit 1)
 				)
 			)
@@ -9309,7 +10719,7 @@
 	)
 	(symbol
 		(lib_id "Connector:Conn_01x04_Pin")
-		(at 21.59 125.73 0)
+		(at 204.47 96.52 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -9318,7 +10728,7 @@
 		(dnp no)
 		(uuid "960ad303-1b34-47ab-87db-3381cbf02442")
 		(property "Reference" "J6"
-			(at 21.59 114.1843 0)
+			(at 204.47 84.9743 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9326,7 +10736,7 @@
 			)
 		)
 		(property "Value" "FAN"
-			(at 21.59 116.84 0)
+			(at 204.47 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9334,7 +10744,7 @@
 			)
 		)
 		(property "Footprint" "Connector:FanPinHeader_1x04_P2.54mm_Vertical"
-			(at 21.59 125.73 0)
+			(at 204.47 96.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9343,7 +10753,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 21.59 125.73 0)
+			(at 204.47 96.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9352,7 +10762,7 @@
 			)
 		)
 		(property "Description" "Generic connector, single row, 01x04, script generated"
-			(at 21.59 125.73 0)
+			(at 204.47 96.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9449,7 +10859,140 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 238.76 60.96 0)
+		(at 229.87 109.22 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "986d000c-b410-4dc5-bc9c-859f368c04de")
+		(property "Reference" "#PWR017"
+			(at 229.87 115.57 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 229.87 113.3531 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 229.87 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 229.87 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 229.87 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb06f9dd-14f3-4a93-8116-00aedcd7ac49")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "#PWR017")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:TestPoint")
+		(at 125.73 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "98a72965-8594-417e-9518-634cd7586484")
+		(property "Reference" "TP3"
+			(at 127.127 79.1902 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "PWREN#"
+			(at 127.127 76.7659 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
+			(at 120.65 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 120.65 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "test point"
+			(at 125.73 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "499a2dfc-27ca-43d7-81ed-19d78b627a5f")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "TP3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 77.47 140.97 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -9459,7 +11002,7 @@
 		(fields_autoplaced yes)
 		(uuid "9a85a8c7-9aab-476a-95f9-de3c69c18af5")
 		(property "Reference" "#PWR035"
-			(at 238.76 67.31 0)
+			(at 77.47 147.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9468,7 +11011,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 238.76 65.0931 0)
+			(at 77.47 145.1031 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9476,7 +11019,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 238.76 60.96 0)
+			(at 77.47 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9485,7 +11028,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 238.76 60.96 0)
+			(at 77.47 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9494,7 +11037,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 238.76 60.96 0)
+			(at 77.47 140.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9516,7 +11059,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 214.63 60.96 0)
+		(at 53.34 163.83 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -9526,7 +11069,7 @@
 		(fields_autoplaced yes)
 		(uuid "9b09d2ae-192d-4169-99bc-7d959bb7bb97")
 		(property "Reference" "#PWR031"
-			(at 214.63 67.31 0)
+			(at 53.34 170.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9535,7 +11078,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 214.63 65.0931 0)
+			(at 53.34 167.9631 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9543,7 +11086,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 214.63 60.96 0)
+			(at 53.34 163.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9552,7 +11095,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 214.63 60.96 0)
+			(at 53.34 163.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9561,7 +11104,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 214.63 60.96 0)
+			(at 53.34 163.83 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9583,7 +11126,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 34.29 35.56 0)
+		(at 91.44 97.79 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -9591,7 +11134,7 @@
 		(dnp no)
 		(uuid "9c4faf3e-6177-4aa3-8648-0c306e511b6d")
 		(property "Reference" "C5"
-			(at 37.211 34.3478 0)
+			(at 94.361 96.5778 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9600,7 +11143,7 @@
 			)
 		)
 		(property "Value" "100n"
-			(at 37.211 36.7721 0)
+			(at 94.361 99.0021 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9609,7 +11152,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 35.2552 39.37 0)
+			(at 92.4052 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9618,7 +11161,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 34.29 35.56 0)
+			(at 91.44 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9627,7 +11170,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 34.29 35.56 0)
+			(at 91.44 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9636,7 +11179,7 @@
 			)
 		)
 		(property "Mouser No" "963-TMK107BJ104MA-T"
-			(at 39.37 39.37 0)
+			(at 96.52 101.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9726,17 +11269,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GNDPWR")
-		(at 60.96 185.42 0)
+		(lib_id "power:GND")
+		(at 128.27 45.72 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "a9fe0548-800c-4f35-8cc6-10b89df869b9")
-		(property "Reference" "#PWR03"
-			(at 60.96 190.5 0)
+		(uuid "a8b3e130-683d-4c5f-8942-79ff064ff5cc")
+		(property "Reference" "#PWR032"
+			(at 128.27 52.07 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9744,8 +11287,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "S-GND"
-			(at 60.833 189.1467 0)
+		(property "Value" "GND"
+			(at 128.27 49.8531 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9753,7 +11296,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 60.96 186.69 0)
+			(at 128.27 45.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9762,7 +11305,73 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 60.96 186.69 0)
+			(at 128.27 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 128.27 45.72 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c651858a-9a46-47bf-8e5f-457e9c0c21d7")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "#PWR032")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GNDPWR")
+		(at 226.06 46.99 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a9fe0548-800c-4f35-8cc6-10b89df869b9")
+		(property "Reference" "#PWR03"
+			(at 226.06 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "S-GND"
+			(at 225.933 50.7167 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 226.06 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 226.06 48.26 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9771,7 +11380,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GNDPWR\" , global ground"
-			(at 60.96 185.42 0)
+			(at 226.06 46.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9793,86 +11402,15 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 118.11 35.56 180)
+		(at 138.43 77.47 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "ac373a79-5f8e-45e8-be36-698aed190e01")
-		(property "Reference" "R14"
-			(at 119.888 34.3478 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "10k"
-			(at 119.888 36.7721 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 119.888 35.56 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 118.11 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 118.11 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "ae6b5d9a-d35c-45c9-ba31-d056df6db8e8")
-		)
-		(pin "1"
-			(uuid "8e4547b8-a90c-4417-8efc-70d2068dc72e")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R14")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 115.57 74.93 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "b034153c-0658-47bc-9ff1-38a5b842232b")
-		(property "Reference" "R13"
-			(at 117.348 73.7178 0)
+		(uuid "b6e4d8d7-cdad-49c5-a4f7-407ab910d734")
+		(property "Reference" "R24"
+			(at 140.208 76.2578 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9881,7 +11419,7 @@
 			)
 		)
 		(property "Value" "2k2"
-			(at 117.348 76.1421 0)
+			(at 140.208 78.6821 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9890,7 +11428,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 117.348 74.93 90)
+			(at 140.208 77.47 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9899,7 +11437,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 115.57 74.93 0)
+			(at 138.43 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9908,7 +11446,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 115.57 74.93 0)
+			(at 138.43 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9917,49 +11455,49 @@
 			)
 		)
 		(pin "2"
-			(uuid "18f06c9f-4327-46cb-ae56-b1604301f2d9")
+			(uuid "21a84ba6-b8ab-4181-9c89-b8694c278f92")
 		)
 		(pin "1"
-			(uuid "8ea37f7b-4554-411e-a331-0e8bf87cb0e4")
+			(uuid "6214f11c-b635-4bf9-aab6-6a68ec75dfa0")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R13")
+					(reference "R24")
 					(unit 1)
 				)
 			)
 		)
 	)
 	(symbol
-		(lib_id "Device:LED")
-		(at 115.57 64.77 90)
+		(lib_id "Device:C")
+		(at 46.99 87.63 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "b82bbf0e-7fd1-4f1b-bd41-d48b6910e141")
-		(property "Reference" "D5"
-			(at 118.491 65.1453 90)
+		(uuid "b76b211f-7f38-435c-9e30-656c32071f66")
+		(property "Reference" "C13"
+			(at 49.911 86.4178 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
-		(property "Value" "Sleep"
-			(at 118.491 67.5696 90)
+		(property "Value" "47p"
+			(at 49.911 88.8421 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 			)
 		)
-		(property "Footprint" "LED_SMD:LED_0603_1608Metric_Pad1.05x0.95mm_HandSolder"
-			(at 115.57 64.77 0)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 47.9552 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9968,7 +11506,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 115.57 64.77 0)
+			(at 46.99 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9976,8 +11514,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Light emitting diode"
-			(at 115.57 64.77 0)
+		(property "Description" "Unpolarized capacitor"
+			(at 46.99 87.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9985,34 +11523,25 @@
 				(hide yes)
 			)
 		)
-		(property "Sim.Pins" "1=K 2=A"
-			(at 115.57 64.77 0)
+		(property "Mouser No" "80-C0603C470K4HACTU"
+			(at 50.8 90.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(hide yes)
 			)
-		)
-		(property "Mouser No" "720-LOQ976-PS-25"
-			(at 113.03 69.85 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "dc4b65c0-42a3-4cb2-9736-a4069da9c629")
 		)
 		(pin "2"
-			(uuid "98e912c8-0382-4d44-9777-efe33aac5a99")
+			(uuid "b1f7a8fb-5e3f-4efe-bd12-42e180c70f33")
+		)
+		(pin "1"
+			(uuid "ce8f1f8d-874e-4309-9175-0aa64f1ae51f")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "D5")
+					(reference "C13")
 					(unit 1)
 				)
 			)
@@ -10079,6 +11608,85 @@
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
 					(reference "#PWR011")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:Conn_01x05_Pin")
+		(at 107.95 62.23 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp yes)
+		(uuid "bc2c2141-d80d-4798-97ee-535cbfa37c0d")
+		(property "Reference" "J8"
+			(at 108.6612 63.4422 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "GPIO"
+			(at 108.6612 61.0179 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x05_P2.54mm_Vertical"
+			(at 107.95 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 107.95 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x05, script generated"
+			(at 107.95 62.23 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "4"
+			(uuid "63b79904-6a4d-4e19-96d2-d5cecf9248e9")
+		)
+		(pin "5"
+			(uuid "4fcabfc3-2bbe-4829-bf1a-83c92caebffc")
+		)
+		(pin "3"
+			(uuid "bcdec78c-1571-43b7-93a1-43174d75492d")
+		)
+		(pin "2"
+			(uuid "2a1d4a28-ec95-428c-a740-3ebc8209b5b4")
+		)
+		(pin "1"
+			(uuid "33f07c86-2574-4dae-8ebb-f2049f732973")
+		)
+		(instances
+			(project ""
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "J8")
 					(unit 1)
 				)
 			)
@@ -10155,17 +11763,16 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 125.73 80.01 0)
+		(lib_id "power:VBUS")
+		(at 34.29 53.34 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "bf52b768-3323-408d-96c2-8d258f9eb3be")
-		(property "Reference" "#PWR029"
-			(at 125.73 86.36 0)
+		(uuid "c08fc1c3-f815-49f5-bf34-d6adeda4d3ae")
+		(property "Reference" "#PWR040"
+			(at 34.29 57.15 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10173,8 +11780,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "GND"
-			(at 125.73 84.1431 0)
+		(property "Value" "VBUS"
+			(at 34.29 49.2069 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10182,7 +11789,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 125.73 80.01 0)
+			(at 34.29 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10191,7 +11798,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 125.73 80.01 0)
+			(at 34.29 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10199,8 +11806,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 125.73 80.01 0)
+		(property "Description" "Power symbol creates a global label with name \"VBUS\""
+			(at 34.29 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10209,12 +11816,12 @@
 			)
 		)
 		(pin "1"
-			(uuid "572e7166-a965-4520-b7ef-a739b954acab")
+			(uuid "42c83757-0781-4ce0-8e3f-4ba655a1938f")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR029")
+					(reference "#PWR040")
 					(unit 1)
 				)
 			)
@@ -10222,7 +11829,7 @@
 	)
 	(symbol
 		(lib_id "Transistor_FET:IRLML6402")
-		(at 66.04 115.57 180)
+		(at 248.92 86.36 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -10230,7 +11837,7 @@
 		(dnp no)
 		(uuid "c160933b-74fb-4834-bb6a-be8bb555bd20")
 		(property "Reference" "Q1"
-			(at 64.77 120.65 0)
+			(at 247.65 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10239,7 +11846,7 @@
 			)
 		)
 		(property "Value" "IRLML6402"
-			(at 64.77 123.0743 0)
+			(at 247.65 93.8643 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10248,7 +11855,7 @@
 			)
 		)
 		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
-			(at 60.96 113.665 0)
+			(at 243.84 84.455 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10259,7 +11866,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.infineon.com/dgdl/irlml6402pbf.pdf?fileId=5546d462533600a401535668d5c2263c"
-			(at 60.96 111.76 0)
+			(at 243.84 82.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10269,7 +11876,7 @@
 			)
 		)
 		(property "Description" "-3.7A Id, -20V Vds, 65mOhm Rds, P-Channel HEXFET Power MOSFET, SOT-23"
-			(at 66.04 115.57 0)
+			(at 248.92 86.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10290,72 +11897,6 @@
 			(project ""
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
 					(reference "Q1")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 104.14 80.01 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "c16da391-1e0d-4412-8ba7-99e0e06acc37")
-		(property "Reference" "#PWR028"
-			(at 104.14 86.36 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 104.14 84.1431 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 104.14 80.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 104.14 80.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 104.14 80.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "ac81845f-bfd4-4f08-b37d-2ae9a15bbaeb")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR028")
 					(unit 1)
 				)
 			)
@@ -10426,35 +11967,35 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:C")
-		(at 52.07 30.48 0)
-		(mirror y)
+		(lib_id "Device:R")
+		(at 107.95 30.48 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c1d7cadb-5a75-474c-9453-3619e24dc587")
-		(property "Reference" "C6"
-			(at 49.149 29.2678 0)
+		(fields_autoplaced yes)
+		(uuid "c21e9ef8-aee3-46f1-92e5-3606c632b460")
+		(property "Reference" "R16"
+			(at 109.728 29.2678 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(justify right)
 			)
 		)
-		(property "Value" "100n"
-			(at 49.149 31.6921 0)
+		(property "Value" "1k"
+			(at 109.728 31.6921 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
+				(justify right)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 51.1048 34.29 0)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 109.728 30.48 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10463,7 +12004,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 52.07 30.48 0)
+			(at 107.95 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10471,17 +12012,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Unpolarized capacitor"
-			(at 52.07 30.48 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Mouser No" "963-TMK107BJ104MA-T"
-			(at 52.07 31.75 0)
+		(property "Description" "Resistor"
+			(at 107.95 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10490,15 +12022,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "efb582a1-b750-43bd-8bba-a5855b3bbf3d")
+			(uuid "5fbdfe6c-d624-49b9-bc3f-f0466d2db650")
 		)
 		(pin "1"
-			(uuid "0a23852d-e645-4dd0-8d4e-3ae54c10b2e4")
+			(uuid "2ebc4b98-7cb2-44ed-83af-f5e00a6ea68e")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "C6")
+					(reference "R16")
 					(unit 1)
 				)
 			)
@@ -10506,7 +12038,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 26.67 41.91 0)
+		(at 123.19 105.41 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -10515,7 +12047,7 @@
 		(fields_autoplaced yes)
 		(uuid "c25a5ccf-be26-4f75-a129-c5831bef82c8")
 		(property "Reference" "#PWR020"
-			(at 26.67 48.26 0)
+			(at 123.19 111.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10524,7 +12056,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 26.67 46.0431 0)
+			(at 123.19 109.5431 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10532,7 +12064,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 26.67 41.91 0)
+			(at 123.19 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10541,7 +12073,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 26.67 41.91 0)
+			(at 123.19 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10550,7 +12082,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 26.67 41.91 0)
+			(at 123.19 105.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10571,35 +12103,33 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:C")
-		(at 38.1 62.23 0)
-		(mirror y)
+		(lib_id "Jumper:Jumper_2_Bridged")
+		(at 118.11 53.34 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "c44d7149-5212-46b9-b6e4-cc4e81f0b935")
-		(property "Reference" "C7"
-			(at 35.179 61.0178 0)
+		(fields_autoplaced yes)
+		(uuid "c4e0f18a-2f5b-4f51-b9d3-14bc068be611")
+		(property "Reference" "JP1"
+			(at 118.11 48.5605 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
-		(property "Value" "47p"
-			(at 35.179 63.4421 0)
+		(property "Value" "UDPI_EN"
+			(at 118.11 50.9848 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify left)
 			)
 		)
-		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 37.1348 66.04 0)
+		(property "Footprint" "Jumper:SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm"
+			(at 118.11 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10608,7 +12138,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 38.1 62.23 0)
+			(at 118.11 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10616,17 +12146,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Unpolarized capacitor"
-			(at 38.1 62.23 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Mouser No" "80-C0603C470K4HACTU"
-			(at 31.75 66.04 0)
+		(property "Description" "Jumper, 2-pole, closed/bridged"
+			(at 118.11 53.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10635,146 +12156,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "383961de-4726-401a-88f9-ad76d1b8188e")
+			(uuid "cf474f3a-e167-4faa-a64f-ba4588e708bb")
 		)
 		(pin "1"
-			(uuid "c78bf605-13b6-4d80-8675-dfe6222dd26d")
+			(uuid "4870ddde-291b-4db7-b08a-8b01f58b9acc")
 		)
 		(instances
-			(project "IntUsbPwmFanController"
+			(project ""
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "C7")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 52.07 36.83 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "c60284d8-4d15-4c9b-a95b-bcf23b96a4c4")
-		(property "Reference" "#PWR025"
-			(at 52.07 43.18 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 52.07 40.9631 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 52.07 36.83 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 52.07 36.83 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 52.07 36.83 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "2fc2bbca-0c1d-4667-97a9-66382d93c526")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR025")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:VBUS")
-		(at 78.74 34.29 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(uuid "c65afca8-8c02-4bb7-b41a-104a5c399250")
-		(property "Reference" "#PWR024"
-			(at 78.74 38.1 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "VBUS"
-			(at 78.74 30.1569 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 78.74 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 78.74 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 78.74 34.29 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "dfc9095f-2d09-459f-af79-981a12bd057d")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR024")
+					(reference "JP1")
 					(unit 1)
 				)
 			)
@@ -10782,7 +12172,223 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 193.04 35.56 90)
+		(at 114.3 97.79 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cbf6c65e-5d1b-409c-bbd7-956164b2dc46")
+		(property "Reference" "R23"
+			(at 116.078 96.5778 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "2k2"
+			(at 116.078 99.0021 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 116.078 97.79 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 114.3 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "6f135607-10e8-4c09-9054-c07ece81cc9a")
+		)
+		(pin "1"
+			(uuid "548994ca-ec35-4629-8fd8-cf1b64ef3a30")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "R23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 52.07 76.2 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "cc262672-fab9-4633-97bb-1a41cc665b45")
+		(property "Reference" "R17"
+			(at 52.07 81.3605 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "27R"
+			(at 52.07 78.9362 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
+			(at 52.07 74.422 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 52.07 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 52.07 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "c0aa1e61-af50-457c-96eb-b67846b5a18e")
+		)
+		(pin "1"
+			(uuid "db49200c-5837-43e2-afcd-1658b9e5f81b")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "R17")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 271.78 101.6 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "cce54aff-d0b7-4f1a-821d-6bdd3a27e59b")
+		(property "Reference" "C6"
+			(at 274.701 100.3878 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100n"
+			(at 274.701 102.8121 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 272.7452 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 271.78 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Mouser No" "963-TMK107BJ104MA-T"
+			(at 276.86 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "d5e76894-4016-46f6-b0b7-5a1d79e99732")
+		)
+		(pin "1"
+			(uuid "e5164f82-2950-4bbf-8240-b6bbadee50d0")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "C6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 33.02 138.43 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -10792,7 +12398,7 @@
 		(fields_autoplaced yes)
 		(uuid "cf5a00f8-a71c-4175-b7b4-90588a18a227")
 		(property "Reference" "R10"
-			(at 193.04 30.3995 90)
+			(at 33.02 133.2695 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10800,7 +12406,7 @@
 			)
 		)
 		(property "Value" "470R"
-			(at 193.04 32.8238 90)
+			(at 33.02 135.6938 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10808,7 +12414,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 193.04 33.782 90)
+			(at 33.02 136.652 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10817,7 +12423,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 193.04 35.56 0)
+			(at 33.02 138.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10826,7 +12432,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 193.04 35.56 0)
+			(at 33.02 138.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10850,17 +12456,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:VBUS")
-		(at 49.53 106.68 0)
-		(mirror y)
+		(lib_id "power:GND")
+		(at 44.45 92.71 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(uuid "d73342c5-d46e-4ead-b6a3-ed0ea65fe0e4")
-		(property "Reference" "#PWR015"
-			(at 49.53 110.49 0)
+		(fields_autoplaced yes)
+		(uuid "d07a1719-0e67-415b-a778-0b2fcdfd167f")
+		(property "Reference" "#PWR039"
+			(at 44.45 99.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10868,8 +12474,8 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "VBUS"
-			(at 49.53 102.5469 0)
+		(property "Value" "GND"
+			(at 44.45 96.8431 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10877,7 +12483,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 49.53 106.68 0)
+			(at 44.45 92.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10886,7 +12492,73 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 49.53 106.68 0)
+			(at 44.45 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 44.45 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7124e466-bc2f-468c-a720-39b2b32e2fcc")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "#PWR039")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:VBUS")
+		(at 229.87 77.47 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d73342c5-d46e-4ead-b6a3-ed0ea65fe0e4")
+		(property "Reference" "#PWR015"
+			(at 229.87 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "VBUS"
+			(at 229.87 73.3369 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 229.87 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 229.87 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10895,7 +12567,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 49.53 106.68 0)
+			(at 229.87 77.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10982,74 +12654,8 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 262.89 29.21 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "dfe13ab7-6d33-4e02-924f-2b673cc741a7")
-		(property "Reference" "#PWR032"
-			(at 262.89 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 262.89 33.3431 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 262.89 29.21 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 262.89 29.21 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 262.89 29.21 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "f1484944-c7bf-4f03-98b1-317bf13f176f")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR032")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "Device:C")
-		(at 238.76 54.61 0)
+		(at 77.47 134.62 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -11058,7 +12664,7 @@
 		(dnp no)
 		(uuid "e064660c-a9bc-4772-9d3d-7b550c61508b")
 		(property "Reference" "C9"
-			(at 235.839 53.3978 0)
+			(at 74.549 133.4078 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11067,7 +12673,7 @@
 			)
 		)
 		(property "Value" "100n"
-			(at 235.839 55.8221 0)
+			(at 74.549 135.8321 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11076,7 +12682,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
-			(at 237.7948 58.42 0)
+			(at 76.5048 138.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11085,7 +12691,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 238.76 54.61 0)
+			(at 77.47 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11094,7 +12700,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 238.76 54.61 0)
+			(at 77.47 134.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11103,7 +12709,7 @@
 			)
 		)
 		(property "Mouser No" "963-TMK107BJ104MA-T"
-			(at 241.3 57.15 0)
+			(at 80.01 137.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11127,8 +12733,74 @@
 		)
 	)
 	(symbol
+		(lib_id "power:GND")
+		(at 40.64 46.99 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e55f851f-4e3a-4df3-a66d-278b24e26faa")
+		(property "Reference" "#PWR038"
+			(at 40.64 53.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 40.64 51.1231 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 40.64 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 40.64 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 40.64 46.99 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97333ae0-4a5c-4cfb-8f9d-98009c8cb7c2")
+		)
+		(instances
+			(project "IntUsbPwmFanController"
+				(path "/0a081858-7105-499c-8ae3-353b1745699c"
+					(reference "#PWR038")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Device:R")
-		(at 68.58 109.22 90)
+		(at 251.46 80.01 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -11138,7 +12810,7 @@
 		(fields_autoplaced yes)
 		(uuid "ea5329eb-79df-49eb-82d7-5e49cbc58e14")
 		(property "Reference" "R12"
-			(at 68.58 104.0595 90)
+			(at 251.46 74.8495 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11146,7 +12818,7 @@
 			)
 		)
 		(property "Value" "100k"
-			(at 68.58 106.4838 90)
+			(at 251.46 77.2738 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11154,7 +12826,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 68.58 107.442 90)
+			(at 251.46 78.232 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11163,7 +12835,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 68.58 109.22 0)
+			(at 251.46 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11172,7 +12844,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 68.58 109.22 0)
+			(at 251.46 80.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11196,33 +12868,34 @@
 		)
 	)
 	(symbol
-		(lib_id "Connector:TestPoint")
-		(at 143.51 189.23 90)
+		(lib_id "Device:C")
+		(at 86.36 97.79 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "ebe39954-39a3-43fb-9655-34c70c64070f")
-		(property "Reference" "TP4"
-			(at 140.208 184.4505 90)
+		(uuid "f2feaa9b-4e42-477b-bdfd-9c72e599ae6a")
+		(property "Reference" "C15"
+			(at 83.439 99.0022 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
-		(property "Value" "TACHO"
-			(at 140.208 186.8748 90)
+		(property "Value" "4u7"
+			(at 83.439 96.5779 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
+				(justify left)
 			)
 		)
-		(property "Footprint" "TestPoint:TestPoint_Pad_D1.0mm"
-			(at 143.51 184.15 0)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric_Pad1.08x0.95mm_HandSolder"
+			(at 85.3948 93.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11231,7 +12904,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 143.51 184.15 0)
+			(at 86.36 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11239,88 +12912,34 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "test point"
-			(at 143.51 189.23 0)
+		(property "Description" "Unpolarized capacitor"
+			(at 86.36 97.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(hide yes)
 			)
+		)
+		(property "Mouser No" "963-TMK107BJ104MA-T"
+			(at 86.36 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a2d6ef63-c14e-44d7-90ea-7b3293646423")
 		)
 		(pin "1"
-			(uuid "9ac0d552-aab3-4aae-9fa6-d225a34a8f27")
+			(uuid "d7b1aaad-e8c1-4c61-b900-e8b52001dfe9")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "TP4")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "power:GND")
-		(at 81.28 77.47 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "ee221bcc-9543-4074-a1c6-82e1932d947f")
-		(property "Reference" "#PWR026"
-			(at 81.28 83.82 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "GND"
-			(at 81.28 81.6031 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 81.28 77.47 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 81.28 77.47 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 81.28 77.47 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "0e5f4d82-d8ff-411a-a9e8-7ce33dc02f20")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "#PWR026")
+					(reference "C15")
 					(unit 1)
 				)
 			)
@@ -11401,7 +13020,7 @@
 	)
 	(symbol
 		(lib_id "power:VBUS")
-		(at 26.67 29.21 0)
+		(at 101.6 91.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -11409,7 +13028,7 @@
 		(dnp no)
 		(uuid "f92a50ca-dc74-4cab-a129-92dfaba6ac01")
 		(property "Reference" "#PWR019"
-			(at 26.67 33.02 0)
+			(at 101.6 95.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11418,7 +13037,7 @@
 			)
 		)
 		(property "Value" "VBUS"
-			(at 26.67 25.0769 0)
+			(at 101.6 87.3069 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11426,7 +13045,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 26.67 29.21 0)
+			(at 101.6 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11435,7 +13054,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 26.67 29.21 0)
+			(at 101.6 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11444,7 +13063,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"VBUS\""
-			(at 26.67 29.21 0)
+			(at 101.6 91.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11466,16 +13085,16 @@
 	)
 	(symbol
 		(lib_id "Device:R")
-		(at 104.14 74.93 180)
+		(at 44.45 30.48 0)
+		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "fa787c94-e0d4-4e45-9594-ded6a98150dd")
-		(property "Reference" "R7"
-			(at 105.918 73.7178 0)
+		(uuid "fee628bf-c5d4-488f-9d7a-62cfc7534563")
+		(property "Reference" "R21"
+			(at 42.672 29.2678 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11483,8 +13102,8 @@
 				(justify right)
 			)
 		)
-		(property "Value" "2k2"
-			(at 105.918 76.1421 0)
+		(property "Value" "4k7"
+			(at 42.672 31.6921 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11493,7 +13112,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 105.918 74.93 90)
+			(at 42.672 30.48 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11502,7 +13121,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 104.14 74.93 0)
+			(at 44.45 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11511,7 +13130,7 @@
 			)
 		)
 		(property "Description" "Resistor"
-			(at 104.14 74.93 0)
+			(at 44.45 30.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11520,85 +13139,15 @@
 			)
 		)
 		(pin "2"
-			(uuid "340ac8d2-0b7b-4d76-8509-51ac16fc22f4")
+			(uuid "3aedcfa4-6b57-49ca-a059-5565813ccffe")
 		)
 		(pin "1"
-			(uuid "7a3fad11-e855-4c65-a4fb-59666825a4cb")
+			(uuid "987d65d9-b900-4fcf-b7cc-b3e9636927f1")
 		)
 		(instances
 			(project "IntUsbPwmFanController"
 				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R7")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:R")
-		(at 106.68 35.56 180)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "fe84f51c-f120-4710-8c33-4d1c1d286925")
-		(property "Reference" "R5"
-			(at 108.458 34.3478 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "1k"
-			(at 108.458 36.7721 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_0603_1608Metric_Pad0.98x0.95mm_HandSolder"
-			(at 108.458 35.56 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 106.68 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 106.68 35.56 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "5a936638-f8b8-414d-a0db-b4e6ad7b0302")
-		)
-		(pin "1"
-			(uuid "6dc66495-9054-4a08-b6d3-38b3e00950f7")
-		)
-		(instances
-			(project "IntUsbPwmFanController"
-				(path "/0a081858-7105-499c-8ae3-353b1745699c"
-					(reference "R5")
+					(reference "R21")
 					(unit 1)
 				)
 			)

--- a/hardware/sym-lib-table
+++ b/hardware/sym-lib-table
@@ -1,0 +1,4 @@
+(sym_lib_table
+  (version 7)
+  (lib (name "FTDI")(type "KiCad")(uri "${KIPRJMOD}/FTDI.kicad_sym")(options "")(descr ""))
+)


### PR DESCRIPTION
I totally missed that the FT201XS is an I²C *slave*, not a master, so it had to be replaced with the FT260S.

### Firmware Changes:
* Updated the `ISR(PORTA_PORT_vect)` logic in `firmware/src/main.c`:
  - `PA7` now receives `PWREN#` instead of `SLEEP`, which is inverted. Adjusted the condition accordingly.

### Hardware Changes:
* Modified `hardware/IntUsbPwmFanController.kicad_pro` to include the FT260S symbol library in the `pinned_symbol_libs` section.
* Replaced the FT201 (I²C slave) with the FT206S (I²C master).